### PR TITLE
First pass at adding locations via POST

### DIFF
--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -199,7 +199,7 @@ class Mongo(object):
         """Append distinct elements to arrays within a file document."""
         # build the query to update the file document
         update_query = {"$addToSet": {}}
-        for key in metadata.keys():
+        for key in metadata:
             if isinstance(metadata[key], list):
                 update_query["$addToSet"][key] = {"$each": metadata[key]}
             else:

--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import datetime
 import logging
 try:
     from collections.abc import Iterable
@@ -192,3 +193,25 @@ class Mongo(object):
     @run_on_executor
     def get_snapshot(self, filters):
         return self.client.snapshots.find_one(filters, {'_id':False})
+
+    @run_on_executor
+    def append_distinct_elements_to_file(self, uuid, metadata):
+        """Append distinct elements to arrays within a file document."""
+        # build the query to update the file document
+        update_query = {"$addToSet": {}}
+        for key in metadata.keys():
+            if isinstance(metadata[key], list):
+                update_query["$addToSet"][key] = {"$each": metadata[key]}
+            else:
+                update_query["$addToSet"][key] = metadata[key]
+
+        # update the file document
+        update_query["$set"] = {"meta_modify_date": str(datetime.datetime.utcnow())}
+        result = self.client.files.update_one({'uuid': uuid}, update_query)
+        # log and/or throw if the update results are surprising
+        if result.modified_count is None:
+            logger.warn('Cannot determine if document has been modified since `result.modified_count` has the value `None`. `result.matched_count` is %s' % result.matched_count)
+        elif result.modified_count != 1:
+            logger.warn('updated %s files with id %r',
+                        result.modified_count, metadata_id)
+            raise Exception('did not update')

--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -208,6 +208,7 @@ class Mongo(object):
         # update the file document
         update_query["$set"] = {"meta_modify_date": str(datetime.datetime.utcnow())}
         result = self.client.files.update_one({'uuid': uuid}, update_query)
+
         # log and/or throw if the update results are surprising
         if result.modified_count is None:
             logger.warn('Cannot determine if document has been modified since `result.modified_count` has the value `None`. `result.matched_count` is %s' % result.matched_count)

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -711,10 +711,11 @@ class SingleFileLocationsHandler(APIHandler):
         # if there are new locations to append
         if new_locations:
             # update the file in the database
-            yield self.db.update_file(uuid, {'locations': new_locations})
+            yield self.db.append_distinct_elements_to_file(uuid, {'locations': new_locations})
+            # re-read the updated file from the database
+            ret = yield self.db.get_file({'uuid': uuid})
 
-        # send the updated record back to the caller
-        ret = yield self.db.get_file({'uuid': uuid})
+        # send the record back to the caller
         ret['_links'] = {
             'self': {'href': os.path.join(self.files_url, uuid)},
             'parent': {'href': self.files_url},

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -125,6 +125,7 @@ class Server(object):
                 (r"/api", HATEOASHandler, api_args),
                 (r"/api/files", FilesHandler, api_args),
                 (r"/api/files/([^\/]+)", SingleFileHandler, api_args),
+                (r"/api/files/([^\/]+)/locations", SingleFileLocationsHandler, api_args),
                 (r"/api/collections", CollectionsHandler, api_args),
                 (r"/api/collections/([^\/]+)", SingleCollectionHandler, api_args),
                 (r"/api/collections/([^\/]+)/files", SingleCollectionFilesHandler, api_args),
@@ -643,6 +644,88 @@ class SingleFileHandler(APIHandler):
             self.write(metadata)
         else:
             self.send_error(404, message='not found')
+
+
+class SingleFileLocationsHandler(APIHandler):
+    """Initialize a handler for add new locations to an existing record."""
+
+    def initialize(self, **kwargs):
+        """Initialize a handler for add new locations to an existing record."""
+        super(SingleFileHandler, self).initialize(**kwargs)
+        self.files_url = os.path.join(self.base_url, 'files')
+        self.validation = Validation(self.config)
+
+    @validate_auth
+    @catch_error
+    @coroutine
+    def post(self, uuid):
+        """Add a location to the record identified by the provided UUID."""
+        # try to load the record from the file catalog by UUID
+        try:
+            ret = yield self.db.get_file({'uuid': uuid})
+        except pymongo.errors.InvalidId:
+            self.send_error(400, message='invalid uuid in POST url')
+            return
+
+        # if we didn't get a record
+        if not ret:
+            self.send_error(404, message='record not found in file catalog')
+            return
+
+        # decode the JSON provided in the POST body
+        metadata = json_decode(self.request.body)
+        locations = metadata.get("locations")
+
+        # if the user didn't provide locations
+        if locations is None:
+            self.send_error(400, message="POST body requires 'locations' field")
+            return
+
+        # if locations isn't a list
+        if not isinstance(locations, list):
+            self.send_error(400, message="field 'locations' must be a list")
+            return
+
+        # for each location provided
+        new_locations = []
+        for loc in locations:
+            # try to load a file by that location
+            check = yield self.db.get_file({'locations': {'$elemMatch': loc}})
+            # if we got a file by that location
+            if check:
+                # if the file we got isn't the one we're trying to update
+                if check['uuid'] != uuid:
+                    # then that location belongs to another file (already exists)
+                    self.send_error(409, message='conflict with existing file (location already exists)',
+                                    file=os.path.join(self.files_url, check['uuid']),
+                                    location=loc)
+                    return
+                # note that if we get the record that we are trying to update
+                # the location will NOT be added to the list of new_locations
+                # which leaves new_locations as a vetted list of addable locations
+            # this is a new location
+            else:
+                # so add it to our list of new locations
+                new_locations.append(loc)
+
+        # add the new locations to the record
+        ret["locations"].extend(new_locations)
+        if not self.validation.validate_metadata_modification(self, ret):
+            return
+
+        # update the record in the database
+        update_metadata = {
+            "locations": ret["locations"]
+        }
+        set_last_modification_date(update_metadata)
+        yield self.db.update_file(uuid, update_metadata)
+
+        # provide the updated record as a response body
+        ret['_links'] = {
+            'self': {'href': os.path.join(self.files_url, uuid)},
+            'parent': {'href': self.files_url},
+        }
+        self.write(ret)
 
 
 ### Collections ###

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -651,9 +651,8 @@ class SingleFileLocationsHandler(APIHandler):
 
     def initialize(self, **kwargs):
         """Initialize a handler for adding new locations to an existing record."""
-        super(SingleFileHandler, self).initialize(**kwargs)
+        super(SingleFileLocationsHandler, self).initialize(**kwargs)
         self.files_url = os.path.join(self.base_url, 'files')
-        self.validation = Validation(self.config)
 
     @validate_auth
     @catch_error

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
-asn1crypto==0.24.0
+asn1crypto==1.1.0
 atomicwrites==1.3.0
-attrs==19.1.0
+attrs==19.2.0
 Babel==2.7.0
 certifi==2019.9.11
 cffi==1.12.3
@@ -11,11 +11,11 @@ cryptography==2.7
 docutils==0.15.2
 idna==2.8
 imagesize==1.1.0
-Jinja2==2.10.1
+Jinja2==2.10.3
 ldap3==2.6.1
 MarkupSafe==1.1.1
 more-itertools==7.2.0
-packaging==19.1
+packaging==19.2
 pluggy==0.13.0
 py==1.8.0
 pyasn1==0.4.7
@@ -24,15 +24,15 @@ Pygments==2.4.2
 PyJWT==1.7.1
 pymongo==3.9.0
 pyparsing==2.4.2
-pytest==5.1.2
-pytz==2019.2
+pytest==5.2.1
+pytz==2019.3
 requests==2.22.0
 requests-futures==1.0.0
 requests-mock==1.7.0
 requests-toolbelt==0.9.1
 rest-tools @ git+https://github.com/WIPACrepo/rest-tools@74b241a7cd83f30b2bf5effac3e2b705dc867a4c#egg=rest_tools
 six==1.12.0
-snowballstemmer==1.9.1
+snowballstemmer==2.0.0
 Sphinx==2.2.0
 sphinxcontrib-applehelp==1.0.1
 sphinxcontrib-devhelp==1.0.1
@@ -41,4 +41,4 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3
 tornado==6.0.3
-urllib3==1.25.3
+urllib3==1.25.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2019.9.11
 cffi==1.13.0
 chardet==3.0.4
 coverage==4.5.4
-cryptography==2.7
+cryptography==2.8
 docutils==0.15.2
 idna==2.8
 imagesize==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 alabaster==0.7.12
-asn1crypto==1.1.0
+asn1crypto==1.2.0
 atomicwrites==1.3.0
-attrs==19.2.0
+attrs==19.3.0
 Babel==2.7.0
 certifi==2019.9.11
-cffi==1.12.3
+cffi==1.13.0
 chardet==3.0.4
 coverage==4.5.4
 cryptography==2.7

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1143,6 +1143,194 @@ class TestFilesAPI(TestServerAPI):
         with self.assertRaises(Exception):
             r.request_seq('PATCH', '/api/files/' + uid, patch1)
 
+    def test_70_abuse_post_files_locations(self):
+        """Abuse the POST /api/files/UUID/locations route to test error handling."""
+        self.start_server()
+        token = self.get_token()
+        r = RestClient(self.address, token, timeout=1, retries=1)
+
+        # define some locations to be tested
+        loc1a = {'site': 'WIPAC', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1b = {'site': 'DESY', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1c = {'site': 'NERSC', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1d = {'site': 'OSG', 'path': '/data/test/exp/IceCube/foo.dat'}
+        locations = [loc1a, loc1b, loc1c, loc1d]
+
+        # try to POST to an invalid UUID
+        valid_post_body = {"locations": locations}
+        with self.assertRaises(Exception):
+            r.request_seq('POST', '/api/files/bobsyeruncle/locations', valid_post_body)
+
+        # try to POST to an non-existant UUID
+        with self.assertRaises(Exception):
+            r.request_seq('POST', '/api/files/6e4ec06d-8e22-4a2b-a392-f4492fb25eb1/locations', valid_post_body)
+
+        # define a file to be created
+        metadata = {
+            'logical_name': '/blah/data/exp/IceCube/blah.dat',
+            'checksum': {'sha512': hex('foo bar')},
+            'file_size': 1,
+            u'locations': [loc1a]
+        }
+
+        # create the file; should be OK
+        data = r.request_seq('POST', '/api/files', metadata)
+        self.assertIn('_links', data)
+        self.assertIn('self', data['_links'])
+        self.assertIn('file', data)
+        url = data['file']
+        uid = url.split('/')[-1]
+
+        # try to POST to the file without a post body
+        with self.assertRaises(Exception):
+            r.request_seq('POST', '/api/files/' + uid + '/locations', {})
+
+        # try to POST to the file with a non-array locations
+        with self.assertRaises(Exception):
+            r.request_seq('POST', '/api/files/' + uid + '/locations', {"locations": "bobsyeruncle"})
+
+    def test_71_post_files_locations_duplicate(self):
+        """Test that POST /api/files/UUID/locations is a no-op for non-distinct locations."""
+        self.start_server()
+        token = self.get_token()
+        r = RestClient(self.address, token, timeout=1, retries=1)
+
+        # define some locations to be tested
+        loc1a = {'site': 'WIPAC', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1b = {'site': 'DESY', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1c = {'site': 'NERSC', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1d = {'site': 'OSG', 'path': '/data/test/exp/IceCube/foo.dat'}
+        locations = [loc1a, loc1b, loc1c, loc1d]
+
+        # define a file to be created
+        metadata = {
+            'logical_name': '/blah/data/exp/IceCube/blah.dat',
+            'checksum': {'sha512': hex('foo bar')},
+            'file_size': 1,
+            u'locations': locations
+        }
+
+        # create the file; should be OK
+        data = r.request_seq('POST', '/api/files', metadata)
+        self.assertIn('_links', data)
+        self.assertIn('self', data['_links'])
+        self.assertIn('file', data)
+        url = data['file']
+        uid = url.split('/')[-1]
+
+        # read the full record of the file; should be OK
+        rec = r.request_seq('GET', '/api/files/' + uid)
+        self.assertEqual(4, len(rec["locations"]))
+        self.assertIn('meta_modify_date', rec)
+        mmd = rec['meta_modify_date']
+
+        # try to POST existant locations to the file; should be OK
+        not_so_new_locations = {"locations": [loc1b, loc1d]}
+        rec2 = r.request_seq('POST', '/api/files/' + uid + '/locations', not_so_new_locations)
+
+        # ensure the record is the same (not updated)
+        self.assertEqual(4, len(rec2["locations"]))
+        self.assertListEqual(rec["locations"], rec2["locations"])
+        self.assertEqual(mmd, rec2["meta_modify_date"])
+
+    def test_72_post_files_locations_conflict(self):
+        """Test that POST /api/files/UUID/locations returns an error on conflicting duplicate locations."""
+        self.start_server()
+        token = self.get_token()
+        r = RestClient(self.address, token, timeout=1, retries=1)
+
+        # define some locations to be tested
+        loc1a = {'site': 'WIPAC', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1b = {'site': 'DESY', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1c = {'site': 'NERSC', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1d = {'site': 'OSG', 'path': '/data/test/exp/IceCube/foo.dat'}
+        locations = [loc1a, loc1b]
+
+        # define a file to be created
+        metadata = {
+            'logical_name': '/blah/data/exp/IceCube/blah.dat',
+            'checksum': {'sha512': hex('foo bar')},
+            'file_size': 1,
+            u'locations': locations
+        }
+
+        # create the file; should be OK
+        data = r.request_seq('POST', '/api/files', metadata)
+        self.assertIn('_links', data)
+        self.assertIn('self', data['_links'])
+        self.assertIn('file', data)
+        url = data['file']
+        uid = url.split('/')[-1]
+
+        # define a second file to be created
+        locations2 = [loc1c, loc1d]
+        metadata2 = {
+            'logical_name': '/blah/data/exp/IceCube/blah2.dat',
+            'checksum': {'sha512': hex('foo bar')},
+            'file_size': 1,
+            u'locations': locations2
+        }
+
+        # create the file; should be OK
+        data = r.request_seq('POST', '/api/files', metadata2)
+        self.assertIn('_links', data)
+        self.assertIn('self', data['_links'])
+        self.assertIn('file', data)
+        url = data['file']
+        uid2 = url.split('/')[-1]
+
+        # try to POST a second file location to the first file
+        with self.assertRaises(Exception):
+            conflicting_locations = {"locations": [loc1d]}
+            rec2 = r.request_seq('POST', '/api/files/' + uid + '/locations', conflicting_locations)
+
+    def test_73_post_files_locations(self):
+        """Test that POST /api/files/UUID/locations can add distinct non-conflicting locations."""
+        self.start_server()
+        token = self.get_token()
+        r = RestClient(self.address, token, timeout=1, retries=1)
+
+        # define some locations to be tested
+        loc1a = {'site': 'WIPAC', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1b = {'site': 'DESY', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1c = {'site': 'NERSC', 'path': '/data/test/exp/IceCube/foo.dat'}
+        loc1d = {'site': 'OSG', 'path': '/data/test/exp/IceCube/foo.dat'}
+        locations = [loc1a, loc1b]
+
+        # define a file to be created
+        metadata = {
+            'logical_name': '/blah/data/exp/IceCube/blah.dat',
+            'checksum': {'sha512': hex('foo bar')},
+            'file_size': 1,
+            u'locations': locations
+        }
+
+        # create the file; should be OK
+        data = r.request_seq('POST', '/api/files', metadata)
+        self.assertIn('_links', data)
+        self.assertIn('self', data['_links'])
+        self.assertIn('file', data)
+        url = data['file']
+        uid = url.split('/')[-1]
+
+        # read the full record of the file; should be OK
+        rec = r.request_seq('GET', '/api/files/' + uid)
+        self.assertEqual(2, len(rec["locations"]))
+        self.assertIn('meta_modify_date', rec)
+        mmd = rec['meta_modify_date']
+
+        # try to POST existant locations to the file; should be OK
+        new_locations = {"locations": [loc1c, loc1d]}
+        rec2 = r.request_seq('POST', '/api/files/' + uid + '/locations', new_locations)
+
+        # ensure the record is the same (not updated)
+        self.assertEqual(4, len(rec2["locations"]))
+        self.assertNotEqual(mmd, rec2["meta_modify_date"])
+        self.assertIn(loc1a, rec2["locations"])
+        self.assertIn(loc1b, rec2["locations"])
+        self.assertIn(loc1c, rec2["locations"])
+        self.assertIn(loc1d, rec2["locations"])
+
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestStringMethods)


### PR DESCRIPTION
JIRA: https://wipacit.atlassian.net/browse/DEV-721

This is a first pass at adding a handler for `POST /api/files/UUID/locations` to allow atomic addition of new locations to a file catalog record.

No unit tests yet, this PR is offered for code review.