### PR TITLE
Add 'all-keys' REST Query Parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             - run: |
                 . env/bin/activate &&
                 resources/enable_profiling.py &&
-                pytest --tb=short &&
+                pytest -vvvvv --tb=short &&
                 resources/profile_queries.py
     deploy:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             - run: |
                 . env/bin/activate &&
                 resources/enable_profiling.py &&
-                pytest -vvvvv --tb=short &&
+                pytest --tb=short &&
                 resources/profile_queries.py
     deploy:
         docker:

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -46,9 +46,10 @@ def build_files_query(kwargs: Dict[str, Any]) -> None:
 
 def build_keys(kwargs: Dict[str, Any]) -> None:
     """Build `"keys"` list, potentially using `"all-keys"` keyword."""
-    use_all_keys = kwargs.pop("all-keys", None) in ["True", "true", 1]
+    if "keys" not in kwargs:
+        return
 
-    if use_all_keys:
+    if kwargs.get("all-keys", None):
         kwargs["keys"] = AllKeys()
-    elif "keys" in kwargs:
+    else:
         kwargs["keys"] = kwargs["keys"].split("|")

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -1,0 +1,55 @@
+"""Builder utility functions for arg/kwargs dicts."""
+
+from typing import Any, Dict
+
+from tornado.escape import json_decode
+
+# local imports
+from file_catalog.mongo import AllKeys
+
+
+def build_files_query(kwargs: Dict[str, Any]) -> None:
+    """Build `"query"` dict with formatted/fully-named arguments.
+
+    Pop corresponding shortcut-keys from `kwargs`.
+    """
+    if "query" in kwargs:
+        # keep whatever was already in here, then add to it
+        if isinstance(kwargs["query"], (str, bytes)):
+            query = json_decode(kwargs.pop("query"))
+        else:
+            query = kwargs.pop("query")
+    else:
+        query = {}
+
+    if "locations.archive" not in query:
+        query["locations.archive"] = None
+
+    # shortcut query params
+    if "logical_name" in kwargs:
+        query["logical_name"] = kwargs.pop("logical_name")
+    if "run_number" in kwargs:
+        query["run.run_number"] = kwargs.pop("run_number")
+    if "dataset" in kwargs:
+        query["iceprod.dataset"] = kwargs.pop("dataset")
+    if "event_id" in kwargs:
+        e = kwargs.pop("event_id")
+        query["run.first_event"] = {"$lte": e}
+        query["run.last_event"] = {"$gte": e}
+    if "processing_level" in kwargs:
+        query["processing_level"] = kwargs.pop("processing_level")
+    if "season" in kwargs:
+        query["offline_processing_metadata.season"] = kwargs.pop("season")
+
+    kwargs["query"] = query
+
+
+def build_keys(kwargs: Dict[str, Any]) -> None:
+    """Build `"keys"` list, potentially using `"all-keys"` keyword."""
+    if "keys" not in kwargs:
+        return
+
+    if kwargs.get("all-keys", None):
+        kwargs["keys"] = AllKeys()
+    else:
+        kwargs["keys"] = kwargs["keys"].split("|")

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -23,6 +23,14 @@ def build_limit(kwargs: Dict[str, Any], config: Dict[str, Any]) -> None:
         kwargs["limit"] = config["FC_QUERY_FILE_LIST_LIMIT"]
 
 
+def build_start(kwargs: Dict[str, Any]) -> None:
+    """Build the `"start"` argument."""
+    if "start" in kwargs:
+        kwargs["start"] = int(kwargs["start"])
+        if kwargs["start"] < 0:
+            raise Exception("start is negative")
+
+
 def build_files_query(kwargs: Dict[str, Any]) -> None:
     """Build `"query"` dict with formatted/fully-named arguments.
 

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -8,6 +8,21 @@ from tornado.escape import json_decode
 from file_catalog.mongo import AllKeys
 
 
+def build_limit(kwargs: Dict[str, Any], config: Dict[str, Any]) -> None:
+    """Build the `"limit"` argument."""
+    if "limit" in kwargs:
+        kwargs["limit"] = int(kwargs["limit"])
+        if kwargs["limit"] < 1:
+            raise Exception("limit is not positive")
+
+        # check with config
+        if kwargs["limit"] > config["FC_QUERY_FILE_LIST_LIMIT"]:
+            kwargs["limit"] = config["FC_QUERY_FILE_LIST_LIMIT"]
+    else:
+        # if no limit has been defined, set max limit
+        kwargs["limit"] = config["FC_QUERY_FILE_LIST_LIMIT"]
+
+
 def build_files_query(kwargs: Dict[str, Any]) -> None:
     """Build `"query"` dict with formatted/fully-named arguments.
 

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -46,10 +46,9 @@ def build_files_query(kwargs: Dict[str, Any]) -> None:
 
 def build_keys(kwargs: Dict[str, Any]) -> None:
     """Build `"keys"` list, potentially using `"all-keys"` keyword."""
-    if "keys" not in kwargs:
-        return
+    use_all_keys = kwargs.pop("all-keys", None) in ["True", "true", 1]
 
-    if kwargs.get("all-keys", None):
+    if use_all_keys:
         kwargs["keys"] = AllKeys()
-    else:
+    elif "keys" in kwargs:
         kwargs["keys"] = kwargs["keys"].split("|")

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -45,11 +45,13 @@ def build_files_query(kwargs: Dict[str, Any]) -> None:
 
 
 def build_keys(kwargs: Dict[str, Any]) -> None:
-    """Build `"keys"` list, potentially using `"all-keys"` keyword."""
-    if "keys" not in kwargs:
-        return
+    """Build `"keys"` list, potentially using `"all-keys"`.
 
-    if kwargs.get("all-keys", None):
+    Pop `"all-keys"`.
+    """
+    use_all_keys = kwargs.pop("all-keys", None) in ["True", "true", 1]
+
+    if use_all_keys:
         kwargs["keys"] = AllKeys()
-    else:
+    elif "keys" in kwargs:
         kwargs["keys"] = kwargs["keys"].split("|")

--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -81,7 +81,7 @@ class Mongo(object):
             if default:  # use default keys if they're available
                 projection.update(default)
         elif isinstance(keys, AllKeys):
-            pass  # only use "id_" constraint in projection
+            pass  # only use "_id" constraint in projection
         elif isinstance(keys, list):
             projection.update({k: True for k in keys})
         else:
@@ -121,7 +121,7 @@ class Mongo(object):
     ) -> List[Dict[str, Any]]:
         """Find files.
 
-        Optionally, apply keyword arguments. "id_" is always excluded.
+        Optionally, apply keyword arguments. "_id" is always excluded.
 
         Decorators:
             run_on_executor
@@ -224,7 +224,7 @@ class Mongo(object):
     ) -> List[Dict[str, Any]]:
         """Find all collections.
 
-        Optionally, apply keyword arguments. "id_" is always excluded.
+        Optionally, apply keyword arguments. "_id" is always excluded.
 
         Decorators:
             run_on_executor
@@ -271,7 +271,7 @@ class Mongo(object):
     ) -> List[Dict[str, Any]]:
         """Find snapshots.
 
-        Optionally, apply keyword arguments. "id_" is always excluded.
+        Optionally, apply keyword arguments. "_id" is always excluded.
 
         Decorators:
             run_on_executor

--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -77,10 +77,11 @@ class Mongo(object):
         default: Optional[Dict[str, bool]] = None,
     ) -> Dict[str, bool]:
         projection = {"_id": False}
-        if not keys and default:
-            projection.update(default)
+        if not keys:
+            if default:  # use default keys if they're available
+                projection.update(default)
         elif isinstance(keys, AllKeys):
-            pass
+            pass  # only use "id_" constraint in projection
         elif isinstance(keys, list):
             projection.update({k: True for k in keys})
         else:

--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -144,7 +144,7 @@ class Mongo(object):
         return ret
 
     @run_on_executor
-    def count_files(self, query: Optional[Dict[str, Any]] = None) -> int:
+    def count_files(self, query: Optional[Dict[str, Any]] = None, **kwargs: Any) -> int:
         """Get count of files matching query."""
         ret = self.client.files.count_documents(query)
         return cast(int, ret)

--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -144,8 +144,12 @@ class Mongo(object):
         return ret
 
     @run_on_executor
-    def count_files(self, query: Optional[Dict[str, Any]] = None, **kwargs: Any) -> int:
+    def count_files(  # pylint: disable=W0613
+        self, query: Optional[Dict[str, Any]] = None, **kwargs: Any,
+    ) -> int:
         """Get count of files matching query."""
+        if not query:
+            query = {}
         ret = self.client.files.count_documents(query)
         return cast(int, ret)
 

--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -77,6 +77,7 @@ class Mongo(object):
         default: Optional[Dict[str, bool]] = None,
     ) -> Dict[str, bool]:
         projection = {"_id": False}
+
         if not keys:
             if default:  # use default keys if they're available
                 projection.update(default)
@@ -88,6 +89,7 @@ class Mongo(object):
             raise TypeError(
                 f"`keys` argument ({keys}) is not NoneType, list, or AllKeys"
             )
+
         return projection
 
     @staticmethod
@@ -109,6 +111,7 @@ class Mongo(object):
 
         for row in result[start:end]:
             ret.append(row)
+
         return ret
 
     @run_on_executor
@@ -150,7 +153,9 @@ class Mongo(object):
         """Get count of files matching query."""
         if not query:
             query = {}
+
         ret = self.client.files.count_documents(query)
+
         return cast(int, ret)
 
     @run_on_executor
@@ -160,9 +165,12 @@ class Mongo(object):
         Return uuid.
         """
         result = self.client.files.insert_one(metadata)
+
         if (not result) or (not result.inserted_id):
-            logger.warning("did not insert file")
-            raise Exception("did not insert new file")
+            msg = "did not insert new file"
+            logger.warning(msg)
+            raise Exception(msg)
+
         return cast(str, metadata["uuid"])
 
     @run_on_executor
@@ -182,8 +190,9 @@ class Mongo(object):
                 result.matched_count,
             )
         elif result.modified_count != 1:
-            logger.warning("updated %s files with id %r", result.modified_count, uuid)
-            raise Exception("did not update")
+            msg = f"updated {result.modified_count} files with id {uuid}"
+            logger.warning(msg)
+            raise Exception(msg)
 
     @run_on_executor
     def replace_file(self, metadata: Dict[str, Any]) -> None:
@@ -201,8 +210,9 @@ class Mongo(object):
                 result.matched_count,
             )
         elif result.modified_count != 1:
-            logger.warning("updated %s files with id %r", result.modified_count, uuid)
-            raise Exception("did not update")
+            msg = f"updated {result.modified_count} files with id {uuid}"
+            logger.warning(msg)
+            raise Exception(msg)
 
     @run_on_executor
     def delete_file(self, filters: Dict[str, Any]) -> None:
@@ -210,10 +220,9 @@ class Mongo(object):
         result = self.client.files.delete_one(filters)
 
         if result.deleted_count != 1:
-            logger.warning(
-                "deleted %d files with filter %r", result.deleted_count, filters
-            )
-            raise Exception("did not delete")
+            msg = f"deleted {result.deleted_count} files with filter {filters}"
+            logger.warning(msg)
+            raise Exception(msg)
 
     @run_on_executor
     def find_collections(
@@ -250,9 +259,12 @@ class Mongo(object):
         Return uuid.
         """
         result = self.client.collections.insert_one(metadata)
+
         if (not result) or (not result.inserted_id):
-            logger.warning("did not insert collection")
-            raise Exception("did not insert new collection")
+            msg = "did not insert new collection"
+            logger.warning(msg)
+            raise Exception(msg)
+
         return cast(str, metadata["uuid"])
 
     @run_on_executor
@@ -295,9 +307,12 @@ class Mongo(object):
     def create_snapshot(self, metadata: Dict[str, Any]) -> str:
         """Insert metadata into 'snapshots' collection."""
         result = self.client.snapshots.insert_one(metadata)
+
         if (not result) or (not result.inserted_id):
-            logger.warning("did not insert snapshot")
-            raise Exception("did not insert new snapshot")
+            msg = "did not insert new snapshot"
+            logger.warning(msg)
+            raise Exception(msg)
+
         return cast(str, metadata["uuid"])
 
     @run_on_executor
@@ -330,5 +345,6 @@ class Mongo(object):
                 result.matched_count,
             )
         elif result.modified_count != 1:
-            logger.warning("updated %s files with id %r", result.modified_count, uuid)
-            raise Exception("did not update")
+            msg = f"updated {result.modified_count} files with id {uuid}"
+            logger.warning(msg)
+            raise Exception(msg)

--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -111,134 +111,203 @@ class Mongo(object):
         return ret
 
     @run_on_executor
-    def count_files(self, query={}, **kwargs):
-        ret = self.client.files.count_documents(query)
+    def find_files(
+        self,
+        query: Optional[Dict[str, Any]] = None,
+        keys: Optional[Union[List[str], AllKeys]] = None,
+        limit: Optional[int] = None,
+        start: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Find files.
+
+        Optionally, apply keyword arguments. "id_" is always excluded.
+
+        Decorators:
+            run_on_executor
+
+        Keyword Arguments:
+            query -- MongoDB query
+            keys -- fields to include in MongoDB projection
+            limit -- max count of files returned
+            start -- starting index
+
+        Returns:
+            List of MongoDB files
+        """
+        projection = Mongo._get_projection(
+            keys, default={"uuid": True, "logical_name": True}
+        )
+        result = self.client.files.find(query, projection)
+        ret = Mongo._limit_result_list(result, limit, start)
+
         return ret
 
     @run_on_executor
-    def create_file(self, metadata):
+    def count_files(self, query: Optional[Dict[str, Any]] = None) -> int:
+        """Get count of files matching query."""
+        ret = self.client.files.count_documents(query)
+        return cast(int, ret)
+
+    @run_on_executor
+    def create_file(self, metadata: Dict[str, Any]) -> str:
+        """Insert file metadata.
+
+        Return uuid.
+        """
         result = self.client.files.insert_one(metadata)
         if (not result) or (not result.inserted_id):
-            logger.warn('did not insert file')
-            raise Exception('did not insert new file')
-        return metadata['uuid']
+            logger.warning("did not insert file")
+            raise Exception("did not insert new file")
+        return cast(str, metadata["uuid"])
 
     @run_on_executor
-    def get_file(self, filters):
-        return self.client.files.find_one(filters, {'_id':False})
+    def get_file(self, filters: Dict[str, Any]) -> Dict[str, Any]:
+        """Get file matching filters."""
+        file = self.client.files.find_one(filters, {"_id": False})
+        return cast(Dict[str, Any], file)
 
     @run_on_executor
-    def update_file(self, uuid, metadata):
-        result = self.client.files.update_one({'uuid': uuid},
-                                              {'$set': metadata})
+    def update_file(self, uuid: str, metadata: Dict[str, Any]) -> None:
+        """Update file."""
+        result = self.client.files.update_one({"uuid": uuid}, {"$set": metadata})
 
         if result.modified_count is None:
-            logger.warn('Cannot determine if document has been modified since `result.modified_count` has the value `None`. `result.matched_count` is %s' % result.matched_count)
+            logger.warning(
+                "Cannot determine if document has been modified since `result.modified_count` has the value `None`. `result.matched_count` is %s",
+                result.matched_count,
+            )
         elif result.modified_count != 1:
-            logger.warn('updated %s files with id %r',
-                        result.modified_count, uuid)
-            raise Exception('did not update')
+            logger.warning("updated %s files with id %r", result.modified_count, uuid)
+            raise Exception("did not update")
 
     @run_on_executor
-    def replace_file(self, metadata):
-        uuid = metadata['uuid']
+    def replace_file(self, metadata: Dict[str, Any]) -> None:
+        """Replace file.
 
-        result = self.client.files.replace_one({'uuid': uuid},
-                                               metadata)
+        Metadata must include 'uuid'.
+        """
+        uuid = metadata["uuid"]
+
+        result = self.client.files.replace_one({"uuid": uuid}, metadata)
 
         if result.modified_count is None:
-            logger.warn('Cannot determine if document has been modified since `result.modified_count` has the value `None`. `result.matched_count` is %s' % result.matched_count)
+            logger.warning(
+                "Cannot determine if document has been modified since `result.modified_count` has the value `None`. `result.matched_count` is %s",
+                result.matched_count,
+            )
         elif result.modified_count != 1:
-            logger.warn('updated %s files with id %r',
-                        result.modified_count, uuid)
-            raise Exception('did not update')
+            logger.warning("updated %s files with id %r", result.modified_count, uuid)
+            raise Exception("did not update")
 
     @run_on_executor
-    def delete_file(self, filters):
+    def delete_file(self, filters: Dict[str, Any]) -> None:
+        """Delete file matching filters."""
         result = self.client.files.delete_one(filters)
 
         if result.deleted_count != 1:
-            logger.warn('deleted %d files with filter %r',
-                        result.deleted_count, filter)
-            raise Exception('did not delete')
+            logger.warning(
+                "deleted %d files with filter %r", result.deleted_count, filters
+            )
+            raise Exception("did not delete")
 
     @run_on_executor
-    def find_collections(self, keys=None, limit=None, start=0):
-        if keys and isinstance(keys,Iterable) and not isinstance(keys,str):
-            projection = {k:True for k in keys}
-        else:
-            projection = {} # show all fields
-        projection['_id'] = False
+    def find_collections(
+        self,
+        keys: Optional[Union[List[str], AllKeys]] = None,
+        limit: Optional[int] = None,
+        start: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Find all collections.
 
+        Optionally, apply keyword arguments. "id_" is always excluded.
+
+        Decorators:
+            run_on_executor
+
+        Keyword Arguments:
+            keys -- fields to include in MongoDB projection
+            limit -- max count of collections returned
+            start -- starting index
+
+        Returns:
+            List of MongoDB collections
+        """
+        projection = Mongo._get_projection(keys)  # show all fields by default
         result = self.client.collections.find({}, projection)
-        ret = []
+        ret = Mongo._limit_result_list(result, limit, start)
 
-        # `limit` and `skip` are ignored by __getitem__:
-        # http://api.mongodb.com/python/current/api/pymongo/cursor.html#pymongo.cursor.Cursor.__getitem__
-        #
-        # Therefore, implement it manually:
-        end = None
-
-        if limit is not None:
-            end = start + limit
-
-        for row in result[start:end]:
-            ret.append(row)
         return ret
 
     @run_on_executor
-    def create_collection(self, metadata):
+    def create_collection(self, metadata: Dict[str, Any]) -> str:
+        """Create collection, insert metadata.
+
+        Return uuid.
+        """
         result = self.client.collections.insert_one(metadata)
         if (not result) or (not result.inserted_id):
-            logger.warn('did not insert collection')
-            raise Exception('did not insert new collection')
-        return metadata['uuid']
+            logger.warning("did not insert collection")
+            raise Exception("did not insert new collection")
+        return cast(str, metadata["uuid"])
 
     @run_on_executor
-    def get_collection(self, filters):
-        return self.client.collections.find_one(filters, {'_id':False})
+    def get_collection(self, filters: Dict[str, Any]) -> Dict[str, Any]:
+        """Get collection matching filters."""
+        collection = self.client.collections.find_one(filters, {"_id": False})
+        return cast(Dict[str, Any], collection)
 
     @run_on_executor
-    def find_snapshots(self, query={}, keys=None, limit=None, start=0):
-        if keys and isinstance(keys,Iterable) and not isinstance(keys,str):
-            projection = {k:True for k in keys}
-        else:
-            projection = {} # show all fields
-        projection['_id'] = False
+    def find_snapshots(
+        self,
+        query: Optional[Dict[str, Any]] = None,
+        keys: Optional[Union[List[str], AllKeys]] = None,
+        limit: Optional[int] = None,
+        start: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Find snapshots.
 
+        Optionally, apply keyword arguments. "id_" is always excluded.
+
+        Decorators:
+            run_on_executor
+
+        Keyword Arguments:
+            query -- MongoDB query
+            keys -- fields to include in MongoDB projection
+            limit -- max count of snapshots returned
+            start -- starting index
+
+        Returns:
+            List of MongoDB snapshots
+        """
+        projection = Mongo._get_projection(keys)  # show all fields by default
         result = self.client.snapshots.find(query, projection)
-        ret = []
+        ret = Mongo._limit_result_list(result, limit, start)
 
-        # `limit` and `skip` are ignored by __getitem__:
-        # http://api.mongodb.com/python/current/api/pymongo/cursor.html#pymongo.cursor.Cursor.__getitem__
-        #
-        # Therefore, implement it manually:
-        end = None
-
-        if limit is not None:
-            end = start + limit
-
-        for row in result[start:end]:
-            ret.append(row)
         return ret
 
     @run_on_executor
-    def create_snapshot(self, metadata):
+    def create_snapshot(self, metadata: Dict[str, Any]) -> str:
+        """Insert metadata into 'snapshots' collection."""
         result = self.client.snapshots.insert_one(metadata)
         if (not result) or (not result.inserted_id):
-            logger.warn('did not insert snapshot')
-            raise Exception('did not insert new snapshot')
-        return metadata['uuid']
+            logger.warning("did not insert snapshot")
+            raise Exception("did not insert new snapshot")
+        return cast(str, metadata["uuid"])
 
     @run_on_executor
-    def get_snapshot(self, filters):
-        return self.client.snapshots.find_one(filters, {'_id':False})
+    def get_snapshot(self, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Find snapshot, optionally filtered."""
+        snapshot = self.client.snapshots.find_one(filters, {"_id": False})
+        return cast(Dict[str, Any], snapshot)
 
     @run_on_executor
-    def append_distinct_elements_to_file(self, uuid, metadata):
+    def append_distinct_elements_to_file(
+        self, uuid: str, metadata: Dict[str, Any]
+    ) -> None:
         """Append distinct elements to arrays within a file document."""
         # build the query to update the file document
-        update_query = {"$addToSet": {}}
+        update_query: Dict[str, Any] = {"$addToSet": {}}
         for key in metadata:
             if isinstance(metadata[key], list):
                 update_query["$addToSet"][key] = {"$each": metadata[key]}
@@ -247,12 +316,14 @@ class Mongo(object):
 
         # update the file document
         update_query["$set"] = {"meta_modify_date": str(datetime.datetime.utcnow())}
-        result = self.client.files.update_one({'uuid': uuid}, update_query)
+        result = self.client.files.update_one({"uuid": uuid}, update_query)
 
         # log and/or throw if the update results are surprising
         if result.modified_count is None:
-            logger.warn('Cannot determine if document has been modified since `result.modified_count` has the value `None`. `result.matched_count` is %s' % result.matched_count)
+            logger.warning(
+                "Cannot determine if document has been modified since `result.modified_count` has the value `None`. `result.matched_count` is %s",
+                result.matched_count,
+            )
         elif result.modified_count != 1:
-            logger.warn('updated %s files with id %r',
-                        result.modified_count, uuid)
-            raise Exception('did not update')
+            logger.warning("updated %s files with id %r", result.modified_count, uuid)
+            raise Exception("did not update")

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -383,20 +383,16 @@ class FilesHandler(APIHandler):
         try:
             kwargs = urlargparse.parse(self.request.query)
             argbuilder.build_limit(kwargs, self.config)
-
-            if 'start' in kwargs:
-                kwargs['start'] = int(kwargs['start'])
-                if kwargs['start'] < 0:
-                    raise Exception('start is negative')
-
+            argbuilder.build_start(kwargs)
             argbuilder.build_files_query(kwargs)
             argbuilder.build_keys(kwargs)
-
         except:
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
             return
+
         files = yield self.db.find_files(**kwargs)
+
         self.write({
             '_links':{
                 'self': {'href': self.files_url},
@@ -491,7 +487,9 @@ class FilesCountHandler(APIHandler):
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
             return
+
         files = yield self.db.count_files(**kwargs)
+
         self.write({
             '_links':{
                 'self': {'href': self.files_url},
@@ -756,19 +754,15 @@ class CollectionsHandler(CollectionBaseHandler):
         try:
             kwargs = urlargparse.parse(self.request.query)
             argbuilder.build_limit(kwargs, self.config)
-
-            if 'start' in kwargs:
-                kwargs['start'] = int(kwargs['start'])
-                if kwargs['start'] < 0:
-                    raise Exception('start is negative')
-
+            argbuilder.build_start(kwargs)
             argbuilder.build_keys(kwargs)
-
         except:
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
             return
+
         collections = yield self.db.find_collections(**kwargs)
+
         self.write({
             '_links':{
                 'self': {'href': self.collections_url},
@@ -785,11 +779,11 @@ class CollectionsHandler(CollectionBaseHandler):
 
         try:
             argbuilder.build_files_query(metadata)
+            metadata['query'] = json_encode(metadata['query'])
         except:
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
             return
-        metadata['query'] = json_encode(metadata['query'])
 
         if 'collection_name' not in metadata:
             self.send_error(400, message='missing collection_name')
@@ -857,20 +851,16 @@ class SingleCollectionFilesHandler(CollectionBaseHandler):
             try:
                 kwargs = urlargparse.parse(self.request.query)
                 argbuilder.build_limit(kwargs, self.config)
-
-                if 'start' in kwargs:
-                    kwargs['start'] = int(kwargs['start'])
-                    if kwargs['start'] < 0:
-                        raise Exception('start is negative')
-
+                argbuilder.build_start(kwargs)
                 kwargs['query'] = json_decode(ret['query'])
                 argbuilder.build_keys(kwargs)
-
             except:
                 logging.warn('query parameter error', exc_info=True)
                 self.send_error(400, message='invalid query parameters')
                 return
+
             files = yield self.db.find_files(**kwargs)
+
             self.write({
                 '_links':{
                     'self': {'href': os.path.join(self.collections_url,uid,'files')},
@@ -897,20 +887,16 @@ class SingleCollectionSnapshotsHandler(CollectionBaseHandler):
         try:
             kwargs = urlargparse.parse(self.request.query)
             argbuilder.build_limit(kwargs, self.config)
-
-            if 'start' in kwargs:
-                kwargs['start'] = int(kwargs['start'])
-                if kwargs['start'] < 0:
-                    raise Exception('start is negative')
-
+            argbuilder.build_start(kwargs)
             argbuilder.build_keys(kwargs)
-
+            kwargs['query'] = {'collection_id': ret['uuid']}
         except:
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
             return
-        kwargs['query'] = {'collection_id': ret['uuid']}
+
         snapshots = yield self.db.find_snapshots(**kwargs)
+
         self.write({
             '_links':{
                 'self': {'href': os.path.join(self.collections_url,uid,'snapshots')},
@@ -1003,22 +989,17 @@ class SingleSnapshotFilesHandler(CollectionBaseHandler):
             try:
                 kwargs = urlargparse.parse(self.request.query)
                 argbuilder.build_limit(kwargs, self.config)
-
-                if 'start' in kwargs:
-                    kwargs['start'] = int(kwargs['start'])
-                    if kwargs['start'] < 0:
-                        raise Exception('start is negative')
-
+                argbuilder.build_start(kwargs)
                 kwargs['query'] = {'uuid':{'$in':ret['files']}}
                 logger.warning('getting files: %r', kwargs['query'])
-
                 argbuilder.build_keys(kwargs)
-
             except:
                 logging.warn('query parameter error', exc_info=True)
                 self.send_error(400, message='invalid query parameters')
                 return
+
             files = yield self.db.find_files(**kwargs)
+
             self.write({
                 '_links':{
                     'self': {'href': os.path.join(self.snapshots_url,uid,'files')},

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -1,3 +1,8 @@
+"""File Catalog REST Server Interface."""
+
+# fmt: off
+# isort:skip_file
+
 from __future__ import absolute_import, division, print_function
 
 import copy
@@ -27,15 +32,17 @@ from tornado.gen import coroutine
 from tornado.httpclient import HTTPError
 from rest_tools.server import Auth
 
+# local imports
 import file_catalog
 from file_catalog.mongo import Mongo
-from file_catalog import urlargparse
+from file_catalog import urlargparse, argbuilder
 from file_catalog.validation import Validation
 
 logger = logging.getLogger('server')
 
+
 def get_pkgdata_filename(package, resource):
-    """Get a filename for a resource bundled within the package"""
+    """Get a filename for a resource bundled within the package."""
     loader = get_loader(package)
     if loader is None or not hasattr(loader, 'get_data'):
         return None
@@ -50,8 +57,9 @@ def get_pkgdata_filename(package, resource):
     parts.insert(0, os.path.dirname(mod.__file__))
     return os.path.join(*parts)
 
+
 def tornado_logger(handler):
-    """Log levels based on status code"""
+    """Log levels based on status code."""
     if handler.get_status() < 400:
         log_method = logger.debug
     elif handler.get_status() < 500:
@@ -62,9 +70,10 @@ def tornado_logger(handler):
     log_method("%d %s %.2fms", handler.get_status(),
             handler._request_summary(), request_time)
 
+
 def sort_dict(d):
-    """
-    Creates an OrderedDict by taking the `dict` named `d` and orders its keys.
+    """Creates an OrderedDict by taking `dict` named `d` and orders its keys.
+
     If a key contains a `dict` it will call this function recursively.
     """
 
@@ -77,11 +86,13 @@ def sort_dict(d):
 
     return od
 
+
 def set_last_modification_date(d):
     d['meta_modify_date'] = str(datetime.datetime.utcnow())
 
+
 class Server(object):
-    """A file_catalog server instance"""
+    """A file_catalog server instance."""
 
     def __init__(self, config, port=8888, debug=False,
                  db_host='localhost', db_port=27017,
@@ -150,8 +161,9 @@ class Server(object):
     def run(self):
         tornado.ioloop.IOLoop.current().start()
 
+
 class MainHandler(tornado.web.RequestHandler):
-    """Main HTML handler"""
+    """Main HTML handler."""
     def initialize(self, base_url='/', debug=False, config=None):
         self.base_url = base_url
         self.debug = debug
@@ -204,8 +216,9 @@ class MainHandler(tornado.web.RequestHandler):
             self.write('<br />'.join(kwargs['message'].split('\n')))
         self.finish()
 
+
 def catch_error(method):
-    """Decorator to catch and handle errors on api handlers"""
+    """Decorator to catch and handle errors on api handlers."""
     @wraps(method)
     def wrapper(self, *args, **kwargs):
         try:
@@ -218,8 +231,9 @@ def catch_error(method):
             self.send_error(**kwargs)
     return wrapper
 
+
 class LoginHandler(MainHandler):
-    """Login HTML handler"""
+    """Login HTML handler."""
     @catch_error
     def get(self):
         if not self.get_argument('access', False):
@@ -240,7 +254,7 @@ class LoginHandler(MainHandler):
 
 
 class AccountHandler(MainHandler):
-    """Account HTML handler"""
+    """Account HTML handler."""
     @catch_error
     def get(self):
         if not self.get_argument('access', False):
@@ -255,8 +269,9 @@ class AccountHandler(MainHandler):
         refresh = self.get_argument('refresh')
         self.render('account.html', authkey=refresh, tempkey=access)
 
+
 def validate_auth(method):
-    """Decorator to check auth key on api handlers"""
+    """Decorator to check auth key on api handlers."""
     @wraps(method)
     def wrapper(self, *args, **kwargs):
         if not self.auth: # skip auth if not present
@@ -278,8 +293,9 @@ def validate_auth(method):
             return method(self, *args, **kwargs)
     return wrapper
 
+
 class APIHandler(tornado.web.RequestHandler):
-    """Base class for API handlers"""
+    """Base class for API handlers."""
     def initialize(self, config, db=None, base_url='/', debug=False, rate_limit=10):
         self.db = db
         self.base_url = base_url
@@ -336,6 +352,7 @@ class APIHandler(tornado.web.RequestHandler):
             self.write(kwargs)
         self.finish()
 
+
 class HATEOASHandler(APIHandler):
     def initialize(self, **kwargs):
         super(HATEOASHandler, self).initialize(**kwargs)
@@ -352,41 +369,6 @@ class HATEOASHandler(APIHandler):
     def get(self):
         self.write(self.data)
 
-
-def build_files_query(kwargs: dict) -> dict:
-    """Return dict with formatted/fully-named arguments for querying files.
-
-    Pop corresponding keys from `kwargs`.
-    """
-    if 'query' in kwargs:
-        # keep whatever was already in here, then add to it
-        if isinstance(kwargs['query'], (str, bytes)):
-            query = json_decode(kwargs.pop('query'))
-        else:
-            query = kwargs.pop('query')
-    else:
-        query = {}
-
-    if 'locations.archive' not in query:
-        query['locations.archive'] = None
-
-    # shortcut query params
-    if 'logical_name' in kwargs:
-        query['logical_name'] = kwargs.pop('logical_name')
-    if 'run_number' in kwargs:
-        query['run.run_number'] = kwargs.pop('run_number')
-    if 'dataset' in kwargs:
-        query['iceprod.dataset'] = kwargs.pop('dataset')
-    if 'event_id' in kwargs:
-        e = kwargs.pop('event_id')
-        query['run.first_event'] = {'$lte': e}
-        query['run.last_event'] = {'$gte': e}
-    if 'processing_level' in kwargs:
-        query['processing_level'] = kwargs.pop('processing_level')
-    if 'season' in kwargs:
-        query['offline_processing_metadata.season'] = kwargs.pop('season')
-
-    return query
 
 class FilesHandler(APIHandler):
     def initialize(self, **kwargs):
@@ -417,10 +399,9 @@ class FilesHandler(APIHandler):
                 if kwargs['start'] < 0:
                     raise Exception('start is negative')
 
-            kwargs['query'] = build_files_query(kwargs)
+            argbuilder.build_files_query(kwargs)
+            argbuilder.build_keys(kwargs)
 
-            if 'keys' in kwargs:
-                kwargs['keys'] = kwargs['keys'].split('|')
         except:
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
@@ -502,6 +483,7 @@ class FilesHandler(APIHandler):
             'file': os.path.join(self.files_url, ret),
         })
 
+
 class FilesCountHandler(APIHandler):
     def initialize(self, **kwargs):
         super(FilesCountHandler, self).initialize(**kwargs)
@@ -514,7 +496,7 @@ class FilesCountHandler(APIHandler):
     def get(self):
         try:
             kwargs = urlargparse.parse(self.request.query)
-            build_files_query(kwargs)
+            argbuilder.build_files_query(kwargs)
         except:
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
@@ -527,6 +509,7 @@ class FilesCountHandler(APIHandler):
             },
             'files': files,
         })
+
 
 class SingleFileHandler(APIHandler):
     def initialize(self, **kwargs):
@@ -695,7 +678,7 @@ class SingleFileLocationsHandler(APIHandler):
     """Initialize a handler for adding new locations to an existing record."""
 
     def initialize(self, **kwargs):
-        """Initialize a handler for adding new locations to an existing record."""
+        """Initialize a handler for adding new locations to existing record."""
         super(SingleFileLocationsHandler, self).initialize(**kwargs)
         self.files_url = os.path.join(self.base_url, 'files')
 
@@ -774,6 +757,7 @@ class CollectionBaseHandler(APIHandler):
         self.collections_url = os.path.join(self.base_url,'collections')
         self.snapshots_url = os.path.join(self.base_url,'snapshots')
 
+
 class CollectionsHandler(CollectionBaseHandler):
     @validate_auth
     @catch_error
@@ -798,8 +782,8 @@ class CollectionsHandler(CollectionBaseHandler):
                 if kwargs['start'] < 0:
                     raise Exception('start is negative')
 
-            if 'keys' in kwargs:
-                kwargs['keys'] = kwargs['keys'].split('|')
+            argbuilder.build_keys(kwargs)
+
         except:
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
@@ -819,14 +803,13 @@ class CollectionsHandler(CollectionBaseHandler):
     def post(self):
         metadata = json_decode(self.request.body)
 
-        query = {}
         try:
-            query = build_files_query(metadata)
+            argbuilder.build_files_query(metadata)
         except:
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
             return
-        metadata['query'] = json_encode(query)
+        metadata['query'] = json_encode(metadata['query'])
 
         if 'collection_name' not in metadata:
             self.send_error(400, message='missing collection_name')
@@ -860,6 +843,7 @@ class CollectionsHandler(CollectionBaseHandler):
             'collection': os.path.join(self.collections_url, ret),
         })
 
+
 class SingleCollectionHandler(CollectionBaseHandler):
     @validate_auth
     @catch_error
@@ -878,6 +862,7 @@ class SingleCollectionHandler(CollectionBaseHandler):
             self.write(ret)
         else:
             self.send_error(404, message='collection not found')
+
 
 class SingleCollectionFilesHandler(CollectionBaseHandler):
     @validate_auth
@@ -909,9 +894,8 @@ class SingleCollectionFilesHandler(CollectionBaseHandler):
                         raise Exception('start is negative')
 
                 kwargs['query'] = json_decode(ret['query'])
+                argbuilder.build_keys(kwargs)
 
-                if 'keys' in kwargs:
-                    kwargs['keys'] = kwargs['keys'].split('|')
             except:
                 logging.warn('query parameter error', exc_info=True)
                 self.send_error(400, message='invalid query parameters')
@@ -926,6 +910,7 @@ class SingleCollectionFilesHandler(CollectionBaseHandler):
             })
         else:
             self.send_error(404, message='collection not found')
+
 
 class SingleCollectionSnapshotsHandler(CollectionBaseHandler):
     @validate_auth
@@ -958,8 +943,8 @@ class SingleCollectionSnapshotsHandler(CollectionBaseHandler):
                 if kwargs['start'] < 0:
                     raise Exception('start is negative')
 
-            if 'keys' in kwargs:
-                kwargs['keys'] = kwargs['keys'].split('|')
+            argbuilder.build_keys(kwargs)
+
         except:
             logging.warn('query parameter error', exc_info=True)
             self.send_error(400, message='invalid query parameters')
@@ -1028,6 +1013,7 @@ class SingleCollectionSnapshotsHandler(CollectionBaseHandler):
                 'snapshot': os.path.join(self.snapshots_url, ret),
             })
 
+
 class SingleSnapshotHandler(CollectionBaseHandler):
     @validate_auth
     @catch_error
@@ -1044,6 +1030,7 @@ class SingleSnapshotHandler(CollectionBaseHandler):
             self.write(ret)
         else:
             self.send_error(404, message='snapshot not found')
+
 
 class SingleSnapshotFilesHandler(CollectionBaseHandler):
     @validate_auth
@@ -1075,8 +1062,8 @@ class SingleSnapshotFilesHandler(CollectionBaseHandler):
                 kwargs['query'] = {'uuid':{'$in':ret['files']}}
                 logger.warning('getting files: %r', kwargs['query'])
 
-                if 'keys' in kwargs:
-                    kwargs['keys'] = kwargs['keys'].split('|')
+                argbuilder.build_keys(**kwargs)
+
             except:
                 logging.warn('query parameter error', exc_info=True)
                 self.send_error(400, message='invalid query parameters')

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -382,17 +382,7 @@ class FilesHandler(APIHandler):
     def get(self):
         try:
             kwargs = urlargparse.parse(self.request.query)
-            if 'limit' in kwargs:
-                kwargs['limit'] = int(kwargs['limit'])
-                if kwargs['limit'] < 1:
-                    raise Exception('limit is not positive')
-
-                # check with config
-                if kwargs['limit'] > self.config['FC_QUERY_FILE_LIST_LIMIT']:
-                    kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
-            else:
-                # if no limit has been defined, set max limit
-                kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
+            argbuilder.build_limit(kwargs, self.config)
 
             if 'start' in kwargs:
                 kwargs['start'] = int(kwargs['start'])
@@ -765,17 +755,7 @@ class CollectionsHandler(CollectionBaseHandler):
     def get(self):
         try:
             kwargs = urlargparse.parse(self.request.query)
-            if 'limit' in kwargs:
-                kwargs['limit'] = int(kwargs['limit'])
-                if kwargs['limit'] < 1:
-                    raise Exception('limit is not positive')
-
-                # check with config
-                if kwargs['limit'] > self.config['FC_QUERY_FILE_LIST_LIMIT']:
-                    kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
-            else:
-                # if no limit has been defined, set max limit
-                kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
+            argbuilder.build_limit(kwargs, self.config)
 
             if 'start' in kwargs:
                 kwargs['start'] = int(kwargs['start'])
@@ -876,17 +856,7 @@ class SingleCollectionFilesHandler(CollectionBaseHandler):
         if ret:
             try:
                 kwargs = urlargparse.parse(self.request.query)
-                if 'limit' in kwargs:
-                    kwargs['limit'] = int(kwargs['limit'])
-                    if kwargs['limit'] < 1:
-                        raise Exception('limit is not positive')
-
-                    # check with config
-                    if kwargs['limit'] > self.config['FC_QUERY_FILE_LIST_LIMIT']:
-                        kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
-                else:
-                    # if no limit has been defined, set max limit
-                    kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
+                argbuilder.build_limit(kwargs, self.config)
 
                 if 'start' in kwargs:
                     kwargs['start'] = int(kwargs['start'])
@@ -926,17 +896,7 @@ class SingleCollectionSnapshotsHandler(CollectionBaseHandler):
 
         try:
             kwargs = urlargparse.parse(self.request.query)
-            if 'limit' in kwargs:
-                kwargs['limit'] = int(kwargs['limit'])
-                if kwargs['limit'] < 1:
-                    raise Exception('limit is not positive')
-
-                # check with config
-                if kwargs['limit'] > self.config['FC_QUERY_FILE_LIST_LIMIT']:
-                    kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
-            else:
-                # if no limit has been defined, set max limit
-                kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
+            argbuilder.build_limit(kwargs, self.config)
 
             if 'start' in kwargs:
                 kwargs['start'] = int(kwargs['start'])
@@ -1042,17 +1002,7 @@ class SingleSnapshotFilesHandler(CollectionBaseHandler):
         if ret:
             try:
                 kwargs = urlargparse.parse(self.request.query)
-                if 'limit' in kwargs:
-                    kwargs['limit'] = int(kwargs['limit'])
-                    if kwargs['limit'] < 1:
-                        raise Exception('limit is not positive')
-
-                    # check with config
-                    if kwargs['limit'] > self.config['FC_QUERY_FILE_LIST_LIMIT']:
-                        kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
-                else:
-                    # if no limit has been defined, set max limit
-                    kwargs['limit'] = self.config['FC_QUERY_FILE_LIST_LIMIT']
+                kwargs["limit"] = int(kwargs["limit"])
 
                 if 'start' in kwargs:
                     kwargs['start'] = int(kwargs['start'])

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -1062,7 +1062,7 @@ class SingleSnapshotFilesHandler(CollectionBaseHandler):
                 kwargs['query'] = {'uuid':{'$in':ret['files']}}
                 logger.warning('getting files: %r', kwargs['query'])
 
-                argbuilder.build_keys(**kwargs)
+                argbuilder.build_keys(kwargs)
 
             except:
                 logging.warn('query parameter error', exc_info=True)

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -1002,7 +1002,7 @@ class SingleSnapshotFilesHandler(CollectionBaseHandler):
         if ret:
             try:
                 kwargs = urlargparse.parse(self.request.query)
-                kwargs["limit"] = int(kwargs["limit"])
+                argbuilder.build_limit(kwargs)
 
                 if 'start' in kwargs:
                     kwargs['start'] = int(kwargs['start'])

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -1002,7 +1002,7 @@ class SingleSnapshotFilesHandler(CollectionBaseHandler):
         if ret:
             try:
                 kwargs = urlargparse.parse(self.request.query)
-                argbuilder.build_limit(kwargs)
+                argbuilder.build_limit(kwargs, self.config)
 
                 if 'start' in kwargs:
                     kwargs['start'] = int(kwargs['start'])

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,13 +1,18 @@
+# fmt:off
+
 from __future__ import absolute_import, division, print_function
 
+import hashlib
 import os
 import unittest
-import hashlib
 
-from tornado.escape import json_encode,json_decode
+from tornado.escape import json_decode, json_encode
+
+# local imports
 from rest_tools.client import RestClient
 
 from .test_server import TestServerAPI
+
 
 def hex(data):
     if isinstance(data, str):
@@ -67,6 +72,76 @@ class TestFilesAPI(TestServerAPI):
         self.assertIn('self', data['_links'])
         self.assertIn('files', data)
         self.assertEqual(data['files'], 1)
+
+    def test_12_files_keys(self):
+        """Test the 'keys' and all-keys' arguments."""
+        self.start_server()
+        token = self.get_token()
+        r = RestClient(self.address, token, timeout=1, retries=1)
+
+        metadata = {
+            "logical_name": "blah",
+            "checksum": {"sha512": hex("foo bar")},
+            "file_size": 1,
+            "locations": [{"site": "test", "path": "blah.dat"}],
+            "extra": "foo",
+            "supplemental": ["green", "eggs", "ham"],
+        }
+        data = r.request_seq("POST", "/api/files", metadata)
+        self.assertIn("_links", data)
+        self.assertIn("self", data["_links"])
+        self.assertIn("file", data)
+        assert "extra" not in data
+        assert "supplemental" not in data
+        url = data["file"]
+        uid = url.split("/")[-1]
+
+        # w/o all-keys
+        data = r.request_seq("GET", "/api/files")
+        assert set(data["files"][0].keys()) == {"logical_name", "uuid"}
+
+        # w/ all-keys
+        body = {"all-keys": True}
+        data = r.request_seq("GET", "/api/files", body)
+        assert set(data["files"][0].keys()) == {
+            "logical_name",
+            "uuid",
+            "checksum",
+            "file_size",
+            "locations",
+            "extra",
+            "supplemental",
+            "meta_modify_date"
+        }
+
+        # w/ all-keys = False
+        body = {"all-keys": False}
+        data = r.request_seq("GET", "/api/files", body)
+        assert set(data["files"][0].keys()) == {"logical_name", "uuid"}
+
+        # w/ all-keys & keys
+        body = {"all-keys": True, "keys": "checksum|file_size"}
+        data = r.request_seq("GET", "/api/files", body)
+        assert set(data["files"][0].keys()) == {
+            "logical_name",
+            "uuid",
+            "checksum",
+            "file_size",
+            "locations",
+            "extra",
+            "supplemental",
+            "meta_modify_date"
+        }
+
+        # w/ all-keys = False & keys
+        body = {"all-keys": False, "keys": "checksum|file_size"}
+        data = r.request_seq("GET", "/api/files", body)
+        assert set(data["files"][0].keys()) == {"checksum", "file_size"}
+
+        # w/ just keys
+        body = {"keys": "checksum|file_size"}
+        data = r.request_seq("GET", "/api/files", body)
+        assert set(data["files"][0].keys()) == {"checksum", "file_size"}
 
     def test_15_files_auth(self):
         self.start_server(config_override={'SECRET':'secret'})
@@ -1197,7 +1272,8 @@ class TestFilesAPI(TestServerAPI):
             r.request_seq('PATCH', '/api/files/' + uid, patch1)
 
     def test_70_abuse_post_files_locations(self):
-        """Abuse the POST /api/files/UUID/locations route to test error handling."""
+        """Abuse the POST /api/files/UUID/locations route to test error
+        handling."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)
@@ -1243,7 +1319,8 @@ class TestFilesAPI(TestServerAPI):
             r.request_seq('POST', '/api/files/' + uid + '/locations', {"locations": "bobsyeruncle"})
 
     def test_71_post_files_locations_duplicate(self):
-        """Test that POST /api/files/UUID/locations is a no-op for non-distinct locations."""
+        """Test that POST /api/files/UUID/locations is a no-op for non-distinct
+        locations."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)
@@ -1287,7 +1364,8 @@ class TestFilesAPI(TestServerAPI):
         self.assertEqual(mmd, rec2["meta_modify_date"])
 
     def test_72_post_files_locations_conflict(self):
-        """Test that POST /api/files/UUID/locations returns an error on conflicting duplicate locations."""
+        """Test that POST /api/files/UUID/locations returns an error on
+        conflicting duplicate locations."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)
@@ -1338,7 +1416,8 @@ class TestFilesAPI(TestServerAPI):
             rec2 = r.request_seq('POST', '/api/files/' + uid + '/locations', conflicting_locations)
 
     def test_73_post_files_locations(self):
-        """Test that POST /api/files/UUID/locations can add distinct non-conflicting locations."""
+        """Test that POST /api/files/UUID/locations can add distinct non-
+        conflicting locations."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)
@@ -1385,7 +1464,8 @@ class TestFilesAPI(TestServerAPI):
         self.assertIn(loc1d, rec2["locations"])
 
     def test_74_post_files_locations_just_one(self):
-        """Test that POST /api/files/UUID/locations can add distinct non-conflicting locations."""
+        """Test that POST /api/files/UUID/locations can add distinct non-
+        conflicting locations."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -101,8 +101,8 @@ class TestFilesAPI(TestServerAPI):
         assert set(data["files"][0].keys()) == {"logical_name", "uuid"}
 
         # w/ all-keys
-        body = {"all-keys": True}
-        data = r.request_seq("GET", "/api/files", body)
+        args = {"all-keys": True}
+        data = r.request_seq("GET", "/api/files", args)
         assert set(data["files"][0].keys()) == {
             "logical_name",
             "uuid",
@@ -115,13 +115,13 @@ class TestFilesAPI(TestServerAPI):
         }
 
         # w/ all-keys = False
-        body = {"all-keys": False}
-        data = r.request_seq("GET", "/api/files", body)
+        args = {"all-keys": False}
+        data = r.request_seq("GET", "/api/files", args)
         assert set(data["files"][0].keys()) == {"logical_name", "uuid"}
 
         # w/ all-keys & keys
-        body = {"all-keys": True, "keys": "checksum|file_size"}
-        data = r.request_seq("GET", "/api/files", body)
+        args = {"all-keys": True, "keys": "checksum|file_size"}
+        data = r.request_seq("GET", "/api/files", args)
         assert set(data["files"][0].keys()) == {
             "logical_name",
             "uuid",
@@ -134,13 +134,13 @@ class TestFilesAPI(TestServerAPI):
         }
 
         # w/ all-keys = False & keys
-        body = {"all-keys": False, "keys": "checksum|file_size"}
-        data = r.request_seq("GET", "/api/files", body)
+        args = {"all-keys": False, "keys": "checksum|file_size"}
+        data = r.request_seq("GET", "/api/files", args)
         assert set(data["files"][0].keys()) == {"checksum", "file_size"}
 
         # w/ just keys
-        body = {"keys": "checksum|file_size"}
-        data = r.request_seq("GET", "/api/files", body)
+        args = {"keys": "checksum|file_size"}
+        data = r.request_seq("GET", "/api/files", args)
         assert set(data["files"][0].keys()) == {"checksum", "file_size"}
 
     def test_15_files_auth(self):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,18 +1,13 @@
-# fmt:off
-
 from __future__ import absolute_import, division, print_function
 
-import hashlib
 import os
 import unittest
+import hashlib
 
-from tornado.escape import json_decode, json_encode
-
-# local imports
+from tornado.escape import json_encode,json_decode
 from rest_tools.client import RestClient
 
 from .test_server import TestServerAPI
-
 
 def hex(data):
     if isinstance(data, str):
@@ -72,76 +67,6 @@ class TestFilesAPI(TestServerAPI):
         self.assertIn('self', data['_links'])
         self.assertIn('files', data)
         self.assertEqual(data['files'], 1)
-
-    def test_12_files_keys(self):
-        """Test the 'keys' and all-keys' arguments."""
-        self.start_server()
-        token = self.get_token()
-        r = RestClient(self.address, token, timeout=1, retries=1)
-
-        metadata = {
-            "logical_name": "blah",
-            "checksum": {"sha512": hex("foo bar")},
-            "file_size": 1,
-            "locations": [{"site": "test", "path": "blah.dat"}],
-            "extra": "foo",
-            "supplemental": ["green", "eggs", "ham"],
-        }
-        data = r.request_seq("POST", "/api/files", metadata)
-        self.assertIn("_links", data)
-        self.assertIn("self", data["_links"])
-        self.assertIn("file", data)
-        assert "extra" not in data
-        assert "supplemental" not in data
-        url = data["file"]
-        uid = url.split("/")[-1]
-
-        # w/o all-keys
-        data = r.request_seq("GET", "/api/files")
-        assert set(data["files"][0].keys()) == {"logical_name", "uuid"}
-
-        # w/ all-keys
-        body = {"all-keys": True}
-        data = r.request_seq("GET", "/api/files", body)
-        assert set(data["files"][0].keys()) == {
-            "logical_name",
-            "uuid",
-            "checksum",
-            "file_size",
-            "locations",
-            "extra",
-            "supplemental",
-            "meta_modify_date"
-        }
-
-        # w/ all-keys = False
-        body = {"all-keys": False}
-        data = r.request_seq("GET", "/api/files", body)
-        assert set(data["files"][0].keys()) == {"logical_name", "uuid"}
-
-        # w/ all-keys & keys
-        body = {"all-keys": True, "keys": "checksum|file_size"}
-        data = r.request_seq("GET", "/api/files", body)
-        assert set(data["files"][0].keys()) == {
-            "logical_name",
-            "uuid",
-            "checksum",
-            "file_size",
-            "locations",
-            "extra",
-            "supplemental",
-            "meta_modify_date"
-        }
-
-        # w/ all-keys = False & keys
-        body = {"all-keys": False, "keys": "checksum|file_size"}
-        data = r.request_seq("GET", "/api/files", body)
-        assert set(data["files"][0].keys()) == {"checksum", "file_size"}
-
-        # w/ just keys
-        body = {"keys": "checksum|file_size"}
-        data = r.request_seq("GET", "/api/files", body)
-        assert set(data["files"][0].keys()) == {"checksum", "file_size"}
 
     def test_15_files_auth(self):
         self.start_server(config_override={'SECRET':'secret'})
@@ -1272,8 +1197,7 @@ class TestFilesAPI(TestServerAPI):
             r.request_seq('PATCH', '/api/files/' + uid, patch1)
 
     def test_70_abuse_post_files_locations(self):
-        """Abuse the POST /api/files/UUID/locations route to test error
-        handling."""
+        """Abuse the POST /api/files/UUID/locations route to test error handling."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)
@@ -1319,8 +1243,7 @@ class TestFilesAPI(TestServerAPI):
             r.request_seq('POST', '/api/files/' + uid + '/locations', {"locations": "bobsyeruncle"})
 
     def test_71_post_files_locations_duplicate(self):
-        """Test that POST /api/files/UUID/locations is a no-op for non-distinct
-        locations."""
+        """Test that POST /api/files/UUID/locations is a no-op for non-distinct locations."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)
@@ -1364,8 +1287,7 @@ class TestFilesAPI(TestServerAPI):
         self.assertEqual(mmd, rec2["meta_modify_date"])
 
     def test_72_post_files_locations_conflict(self):
-        """Test that POST /api/files/UUID/locations returns an error on
-        conflicting duplicate locations."""
+        """Test that POST /api/files/UUID/locations returns an error on conflicting duplicate locations."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)
@@ -1416,8 +1338,7 @@ class TestFilesAPI(TestServerAPI):
             rec2 = r.request_seq('POST', '/api/files/' + uid + '/locations', conflicting_locations)
 
     def test_73_post_files_locations(self):
-        """Test that POST /api/files/UUID/locations can add distinct non-
-        conflicting locations."""
+        """Test that POST /api/files/UUID/locations can add distinct non-conflicting locations."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)
@@ -1464,8 +1385,7 @@ class TestFilesAPI(TestServerAPI):
         self.assertIn(loc1d, rec2["locations"])
 
     def test_74_post_files_locations_just_one(self):
-        """Test that POST /api/files/UUID/locations can add distinct non-
-        conflicting locations."""
+        """Test that POST /api/files/UUID/locations can add distinct non-conflicting locations."""
         self.start_server()
         token = self.get_token()
         r = RestClient(self.address, token, timeout=1, retries=1)


### PR DESCRIPTION
I've added an `"all-keys"` REST query parameter which essentially overrides `"keys"` by returning the FC files with their entire metadata. This new parameter is intended to be a bool/flag. All enhancements are backwards compatible and tested.

### This has several advantages:
1. Performance is increased **considerably** when querying `/api/files` versus multiple queries to `api/file/<uuid>`
2. This doesn't require the REST client/user to know what fields are available. That's useful since the file metadata schema varies among file types.
3. Individual REST routes can maintain their default keys when no `"keys"` parameter is included. Eg: `api/file/<uuid>` provides `"logical_name"` and `"uuid"` by default.

### Notes:
- `argbuilder.py` includes utility functions for constructing common arguments that are first parsed by `urlargparse.parse()`
-  `"all-keys"` is available for all routes where `"keys"` is. See `argbuilder.py`.
     + _only `/api/files/` has been tested so far_
- `mongo.py` has been updated, as well as type-hinted, formatted, and documented
     + an `AllKeys` instance is used as an indicator and to prevent convoluted multiple parameter logic.