### PR TITLE
Add Path-Like Arguments for Querying Files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     test:
         docker:
-            - image: circleci/python:3.7.2
+            - image: circleci/python:3.8
               environment:
                 # Both TEST_DATABASE_HOST and TEST_DATABASE_PORT must be defined.
                 # Things will break if host is defined and port isn't or vice-versa.

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -30,7 +30,7 @@ def build_start(kwargs: Dict[str, Any]) -> None:
             raise Exception("start is negative")
 
 
-def _resolve_path_args(kwargs: Dict[str, Any]) -> None:
+def _resolve_path_args(kwargs: Dict[str, Any]) -> Optional[Union[Dict[str, Any], str]]:
     """Resolve the path-type shortcut arguments by precedence.
 
     Pop each key from `kwargs`, even if it's not used.
@@ -55,8 +55,7 @@ def _resolve_path_args(kwargs: Dict[str, Any]) -> None:
             fname = r".*"
         arg = {"$regex": rf"^{dpath}((/)|(/.*/)){fname}$"}
 
-    if arg:
-        kwargs["logical_name"] = arg
+    return arg
 
 
 def build_files_query(kwargs: Dict[str, Any]) -> None:
@@ -77,7 +76,8 @@ def build_files_query(kwargs: Dict[str, Any]) -> None:
         query["locations.archive"] = None
 
     # shortcut query params
-    _resolve_path_args(kwargs)
+    if path := _resolve_path_args(kwargs):
+        query["logical_name"] = path
     if "run_number" in kwargs:
         query["run.run_number"] = kwargs.pop("run_number")
     if "dataset" in kwargs:

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -49,8 +49,10 @@ def _resolve_path_args(kwargs: Dict[str, Any]) -> None:
 
     # directory & filename
     if "directory" in kwargs or "filename" in kwargs:
-        dpath = kwargs.pop("directory", "").rstrip("/")
-        fname = kwargs.pop("filename", "").lstrip("/")
+        if not (dpath := kwargs.pop("directory", "").rstrip("/")):
+            dpath = r".*"
+        if not (fname := kwargs.pop("filename", "").lstrip("/")):
+            fname = r".*"
         arg = {"$regex": rf"^{dpath}((/)|(/.*/)){fname}$"}
 
     if arg:

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -51,7 +51,7 @@ def _handle_path_args(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     if "directory" in kwargs or "filename" in kwargs:
         dpath = kwargs.pop("directory", "").rstrip("/")
         fname = kwargs.pop("filename", "").lstrip("/")
-        arg = {"$regex": rf"^{dpath}((/)|(/.*/)){fname}.*"}
+        arg = {"$regex": rf"^{dpath}((/)|(/.*/)){fname}$"}
 
     return {"logical_name": arg}
 

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -41,23 +41,17 @@ def _handle_path_args(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     if "path-regex" in kwargs:
         arg = {"$regex": kwargs.pop("path-regex")}
 
-    # start & end
-    if "path-start" in kwargs:
-        arg = {"$regex": rf"^{kwargs.pop('path-start')}.*"}
-    if "path-end" in kwargs:
-        arg = {"$regex": rf"^.*{kwargs.pop('path-end')}$"}
-
     # normal path
     if "path" in kwargs:
         arg = kwargs.pop("path")
     if "logical_name" in kwargs:
         arg = kwargs.pop("logical_name")
 
-    # directory
-    if dpath := kwargs.pop("directory", None):
-        if not dpath.endswith("/"):
-            dpath += "/"
-        arg = {"$regex": rf"^{dpath}.*"}
+    # directory & filename
+    if "directory" in kwargs or "filename" in kwargs:
+        dpath = kwargs.pop("directory", "").rstrip("/")
+        fname = kwargs.pop("filename", "").lstrip("/")
+        arg = {"$regex": rf"^{dpath}((/)|(/.*/)){fname}.*"}
 
     return {"logical_name": arg}
 

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -53,7 +53,7 @@ def _resolve_path_args(kwargs: Dict[str, Any]) -> Optional[Union[Dict[str, Any],
             dpath = r".*"
         if not (fname := kwargs.pop("filename", "").lstrip("/")):
             fname = r".*"
-        arg = {"$regex": rf"^{dpath}((/)|(/.*/)){fname}$"}
+        arg = {"$regex": rf"^{dpath}/(.*/)?{fname}$"}
 
     return arg
 

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -1,11 +1,10 @@
 """Builder utility functions for arg/kwargs dicts."""
 
-from typing import Any, Dict
 
-from tornado.escape import json_decode
+from typing import Any, Dict, Union
 
-# local imports
 from file_catalog.mongo import AllKeys
+from tornado.escape import json_decode
 
 
 def build_limit(kwargs: Dict[str, Any], config: Dict[str, Any]) -> None:
@@ -31,6 +30,38 @@ def build_start(kwargs: Dict[str, Any]) -> None:
             raise Exception("start is negative")
 
 
+def _handle_path_args(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Handle the path-type shortcut arguments by precedence.
+
+    Pop each key from `kwargs`, even if it's not used.
+    """
+    arg: Union[Dict[str, Any], str] = {}
+
+    # regex
+    if "path-regex" in kwargs:
+        arg = {"$regex": kwargs.pop("path-regex")}
+
+    # start & end
+    if "path-start" in kwargs:
+        arg = {"$regex": rf"^{kwargs.pop('path-start')}.*"}
+    if "path-end" in kwargs:
+        arg = {"$regex": rf"^.*{kwargs.pop('path-end')}$"}
+
+    # normal path
+    if "path" in kwargs:
+        arg = kwargs.pop("path")
+    if "logical_name" in kwargs:
+        arg = kwargs.pop("logical_name")
+
+    # directory
+    if dpath := kwargs.pop("directory", None):
+        if not dpath.endswith("/"):
+            dpath += "/"
+        arg = {"$regex": rf"^{dpath}.*"}
+
+    return {"logical_name": arg}
+
+
 def build_files_query(kwargs: Dict[str, Any]) -> None:
     """Build `"query"` dict with formatted/fully-named arguments.
 
@@ -49,8 +80,7 @@ def build_files_query(kwargs: Dict[str, Any]) -> None:
         query["locations.archive"] = None
 
     # shortcut query params
-    if "logical_name" in kwargs:
-        query["logical_name"] = kwargs.pop("logical_name")
+    query.update(_handle_path_args(kwargs))
     if "run_number" in kwargs:
         query["run.run_number"] = kwargs.pop("run_number")
     if "dataset" in kwargs:

--- a/tests/test_argbuilder.py
+++ b/tests/test_argbuilder.py
@@ -3,7 +3,7 @@
 # pylint: disable=W0212
 
 import pprint
-from typing import Any, Dict, List, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 from file_catalog import argbuilder
 
@@ -14,71 +14,71 @@ def test_00_path_args() -> None:
     class KwargsTests(TypedDict):  # pylint: disable=C0115
         kwargs_in: Dict[str, Any]
         kwargs_after: Dict[str, Any]
+        ret: Optional[Union[Dict[str, Any], str]]
 
     kwargs_test_dicts: List[KwargsTests] = [
         # null case
-        {"kwargs_in": {}, "kwargs_after": {}},
+        {"kwargs_in": {}, "kwargs_after": {}, "ret": None},
         # no path-args
         {
             "kwargs_in": {"an-extra-argument": [12, 34, 56]},
             "kwargs_after": {"an-extra-argument": [12, 34, 56]},
+            "ret": None,
         },
         # only "path-regex"
         {
             "kwargs_in": {"path-regex": r"/reg-ex/this.*/(file/)?path"},
-            "kwargs_after": {
-                "logical_name": {"$regex": r"/reg-ex/this.*/(file/)?path"}
-            },
+            "kwargs_after": {},
+            "ret": {"$regex": r"/reg-ex/this.*/(file/)?path"},
         },
         # only "path"
         {
             "kwargs_in": {"an-extra-argument": [12, 34, 56], "path": "PATH"},
-            "kwargs_after": {"an-extra-argument": [12, 34, 56], "logical_name": "PATH"},
+            "kwargs_after": {"an-extra-argument": [12, 34, 56]},
+            "ret": "PATH",
         },
         # only "logical_name"
         {
             "kwargs_in": {"logical_name": "LOGICAL_NAME"},
-            "kwargs_after": {"logical_name": "LOGICAL_NAME"},
+            "kwargs_after": {},
+            "ret": "LOGICAL_NAME",
         },
         # only "directory"
         {
             "kwargs_in": {"directory": "/path/to/dir/"},
-            "kwargs_after": {
-                "logical_name": {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"},
-            },
+            "kwargs_after": {},
+            "ret": {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"},
         },
         # only "directory" w/o trailing '/'
         {
             "kwargs_in": {"directory": "/path/to/dir"},
-            "kwargs_after": {
-                "logical_name": {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"},
-            },
+            "kwargs_after": {},
+            "ret": {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"},
         },
         # only "filename"
         {
             "kwargs_in": {"filename": "my-file"},
-            "kwargs_after": {"logical_name": {"$regex": r"^.*((/)|(/.*/))my-file$"}},
+            "kwargs_after": {},
+            "ret": {"$regex": r"^.*((/)|(/.*/))my-file$"},
         },
         # only "filename" w/ a sub-directory
         {
             "kwargs_in": {"filename": "/sub-dir/my-file"},
-            "kwargs_after": {
-                "logical_name": {"$regex": r"^.*((/)|(/.*/))sub-dir/my-file$"}
-            },
+            "kwargs_after": {},
+            "ret": {"$regex": r"^.*((/)|(/.*/))sub-dir/my-file$"},
         },
         # "directory" & "filename"
         {
             "kwargs_in": {"directory": "/path/to/dir/", "filename": "my-file"},
-            "kwargs_after": {
-                "logical_name": {"$regex": r"^/path/to/dir((/)|(/.*/))my-file$"}
-            },
+            "kwargs_after": {},
+            "ret": {"$regex": r"^/path/to/dir((/)|(/.*/))my-file$"},
         },
     ]
 
     for ktd in kwargs_test_dicts:
         pprint.pprint(ktd)
         print()
-        argbuilder._resolve_path_args(ktd["kwargs_in"])
+        assert argbuilder._resolve_path_args(ktd["kwargs_in"]) == ktd["ret"]
         assert ktd["kwargs_in"] == ktd["kwargs_after"]
 
     # test multiple path-args (each loop pops the arg of the highest precedence)
@@ -92,6 +92,6 @@ def test_00_path_args() -> None:
     while args:
         kwargs = {k: v for (k, v, _) in args}
         pprint.pprint(kwargs)
-        argbuilder._resolve_path_args(kwargs)
-        assert kwargs == {"logical_name": args[0][2]}
+        assert argbuilder._resolve_path_args(kwargs) == args[0][2]
+        assert not kwargs  # everything was popped
         args.pop(0)

--- a/tests/test_argbuilder.py
+++ b/tests/test_argbuilder.py
@@ -47,31 +47,31 @@ def test_00_path_args() -> None:
         {
             "kwargs_in": {"directory": "/path/to/dir/"},
             "kwargs_after": {},
-            "ret": {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"},
+            "ret": {"$regex": r"^/path/to/dir/(.*/)?.*$"},
         },
         # only "directory" w/o trailing '/'
         {
             "kwargs_in": {"directory": "/path/to/dir"},
             "kwargs_after": {},
-            "ret": {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"},
+            "ret": {"$regex": r"^/path/to/dir/(.*/)?.*$"},
         },
         # only "filename"
         {
             "kwargs_in": {"filename": "my-file"},
             "kwargs_after": {},
-            "ret": {"$regex": r"^.*((/)|(/.*/))my-file$"},
+            "ret": {"$regex": r"^.*/(.*/)?my-file$"},
         },
         # only "filename" w/ a sub-directory
         {
             "kwargs_in": {"filename": "/sub-dir/my-file"},
             "kwargs_after": {},
-            "ret": {"$regex": r"^.*((/)|(/.*/))sub-dir/my-file$"},
+            "ret": {"$regex": r"^.*/(.*/)?sub-dir/my-file$"},
         },
         # "directory" & "filename"
         {
             "kwargs_in": {"directory": "/path/to/dir/", "filename": "my-file"},
             "kwargs_after": {},
-            "ret": {"$regex": r"^/path/to/dir((/)|(/.*/))my-file$"},
+            "ret": {"$regex": r"^/path/to/dir/(.*/)?my-file$"},
         },
     ]
 
@@ -83,7 +83,7 @@ def test_00_path_args() -> None:
 
     # test multiple path-args (each loop pops the arg of the highest precedence)
     args = [  # list in decreasing order of precedence
-        ("directory", "/path/to/dir/", {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"}),
+        ("directory", "/path/to/dir/", {"$regex": r"^/path/to/dir/(.*/)?.*$"}),
         # not testing "filename" b/c that is equal to "directory" in precedence
         ("logical_name", "LOGICAL_NAME", "LOGICAL_NAME"),
         ("path", "PATH", "PATH"),

--- a/tests/test_argbuilder.py
+++ b/tests/test_argbuilder.py
@@ -1,0 +1,11 @@
+"""Test argbuilder.py functions."""
+
+# pylint: disable=W0212
+
+from file_catalog import argbuilder
+
+
+def test_00_path_args() -> None:
+    """Test _handle_path_args."""
+    assert argbuilder._handle_path_args({}) == {}
+    assert argbuilder._handle_path_args({"foo": 5}) == {"foo": 5}

--- a/tests/test_argbuilder.py
+++ b/tests/test_argbuilder.py
@@ -2,10 +2,103 @@
 
 # pylint: disable=W0212
 
+import pprint
+from collections import OrderedDict
+from typing import Any, Dict, List, TypedDict
+
 from file_catalog import argbuilder
 
 
 def test_00_path_args() -> None:
     """Test _handle_path_args."""
-    assert argbuilder._handle_path_args({}) == {}
-    assert argbuilder._handle_path_args({"foo": 5}) == {"foo": 5}
+
+    class KwargsTests(TypedDict):  # pylint: disable=C0115
+        kwargs_in: Dict[str, Any]
+        kwargs_after: Dict[str, Any]
+
+    path_regex = r"/reg-ex/this.*/(file/)?path"
+    path = "PATH"
+    logical_name = "LOGICAL_NAME"
+    directory = "/path/to/dir/"
+    filename = "my-file"
+
+    kwargs_test_dicts: List[KwargsTests] = [
+        # null case
+        {"kwargs_in": {}, "kwargs_after": {}},
+        # no path-args
+        {
+            "kwargs_in": {"an-extra-argument": [12, 34, 56]},
+            "kwargs_after": {"an-extra-argument": [12, 34, 56]},
+        },
+        # only "path-regex"
+        {
+            "kwargs_in": {"path-regex": path_regex},
+            "kwargs_after": {"logical_name": {"$regex": path_regex}},
+        },
+        # only "path"
+        {
+            "kwargs_in": {"an-extra-argument": [12, 34, 56], "path": path},
+            "kwargs_after": {"an-extra-argument": [12, 34, 56], "logical_name": path},
+        },
+        # only "logical_name"
+        {
+            "kwargs_in": {"logical_name": logical_name},
+            "kwargs_after": {"logical_name": logical_name},
+        },
+        # only "directory"
+        {
+            "kwargs_in": {"directory": directory},
+            "kwargs_after": {
+                "logical_name": {"$regex": rf"^{directory.rstrip('/')}((/)|(/.*/)).*$"},
+            },
+        },
+        # only "directory" w/o trailing '/'
+        {
+            "kwargs_in": {"directory": "/path/to/dir/"},
+            "kwargs_after": {
+                "logical_name": {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"},
+            },
+        },
+        # only "filename"
+        {
+            "kwargs_in": {"filename": filename},
+            "kwargs_after": {
+                "logical_name": {"$regex": rf"^.*((/)|(/.*/)){filename}$"}
+            },
+        },
+        # only "filename" w/ a sub-directory
+        {
+            "kwargs_in": {"filename": "/sub-dir/my-file"},
+            "kwargs_after": {
+                "logical_name": {"$regex": r"^.*((/)|(/.*/))sub-dir/my-file$"}
+            },
+        },
+        # "directory" & "filename"
+        {
+            "kwargs_in": {"directory": directory, "filename": filename},
+            "kwargs_after": {
+                "logical_name": {"$regex": r"^/path/to/dir((/)|(/.*/))my-file$"}
+            },
+        },
+    ]
+
+    for ktd in kwargs_test_dicts:
+        pprint.pprint(ktd)
+        print()
+        argbuilder._resolve_path_args(ktd["kwargs_in"])
+        assert ktd["kwargs_in"] == ktd["kwargs_after"]
+
+    # test multiple path-args (each loop pops the arg of the highest precedence)
+    args = [  # list in decreasing order of precedence
+        ("directory", directory, {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"}),
+        # not testing "filename" b/c that is equal to "directory" in precedence
+        ("logical_name", logical_name, logical_name),
+        ("path", path, path),
+        ("path-regex", path_regex, {"$regex": path_regex}),
+    ]
+    while args:
+        kwargs = {k: v for (k, v, _) in args}
+        pprint.pprint(kwargs)
+        argbuilder._resolve_path_args(kwargs)
+        assert kwargs == {"logical_name": args[0][2]}
+        args.pop(0)

--- a/tests/test_argbuilder.py
+++ b/tests/test_argbuilder.py
@@ -3,7 +3,6 @@
 # pylint: disable=W0212
 
 import pprint
-from collections import OrderedDict
 from typing import Any, Dict, List, TypedDict
 
 from file_catalog import argbuilder

--- a/tests/test_argbuilder.py
+++ b/tests/test_argbuilder.py
@@ -15,12 +15,6 @@ def test_00_path_args() -> None:
         kwargs_in: Dict[str, Any]
         kwargs_after: Dict[str, Any]
 
-    path_regex = r"/reg-ex/this.*/(file/)?path"
-    path = "PATH"
-    logical_name = "LOGICAL_NAME"
-    directory = "/path/to/dir/"
-    filename = "my-file"
-
     kwargs_test_dicts: List[KwargsTests] = [
         # null case
         {"kwargs_in": {}, "kwargs_after": {}},
@@ -31,39 +25,39 @@ def test_00_path_args() -> None:
         },
         # only "path-regex"
         {
-            "kwargs_in": {"path-regex": path_regex},
-            "kwargs_after": {"logical_name": {"$regex": path_regex}},
+            "kwargs_in": {"path-regex": r"/reg-ex/this.*/(file/)?path"},
+            "kwargs_after": {
+                "logical_name": {"$regex": r"/reg-ex/this.*/(file/)?path"}
+            },
         },
         # only "path"
         {
-            "kwargs_in": {"an-extra-argument": [12, 34, 56], "path": path},
-            "kwargs_after": {"an-extra-argument": [12, 34, 56], "logical_name": path},
+            "kwargs_in": {"an-extra-argument": [12, 34, 56], "path": "PATH"},
+            "kwargs_after": {"an-extra-argument": [12, 34, 56], "logical_name": "PATH"},
         },
         # only "logical_name"
         {
-            "kwargs_in": {"logical_name": logical_name},
-            "kwargs_after": {"logical_name": logical_name},
+            "kwargs_in": {"logical_name": "LOGICAL_NAME"},
+            "kwargs_after": {"logical_name": "LOGICAL_NAME"},
         },
         # only "directory"
-        {
-            "kwargs_in": {"directory": directory},
-            "kwargs_after": {
-                "logical_name": {"$regex": rf"^{directory.rstrip('/')}((/)|(/.*/)).*$"},
-            },
-        },
-        # only "directory" w/o trailing '/'
         {
             "kwargs_in": {"directory": "/path/to/dir/"},
             "kwargs_after": {
                 "logical_name": {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"},
             },
         },
+        # only "directory" w/o trailing '/'
+        {
+            "kwargs_in": {"directory": "/path/to/dir"},
+            "kwargs_after": {
+                "logical_name": {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"},
+            },
+        },
         # only "filename"
         {
-            "kwargs_in": {"filename": filename},
-            "kwargs_after": {
-                "logical_name": {"$regex": rf"^.*((/)|(/.*/)){filename}$"}
-            },
+            "kwargs_in": {"filename": "my-file"},
+            "kwargs_after": {"logical_name": {"$regex": r"^.*((/)|(/.*/))my-file$"}},
         },
         # only "filename" w/ a sub-directory
         {
@@ -74,7 +68,7 @@ def test_00_path_args() -> None:
         },
         # "directory" & "filename"
         {
-            "kwargs_in": {"directory": directory, "filename": filename},
+            "kwargs_in": {"directory": "/path/to/dir/", "filename": "my-file"},
             "kwargs_after": {
                 "logical_name": {"$regex": r"^/path/to/dir((/)|(/.*/))my-file$"}
             },
@@ -89,11 +83,11 @@ def test_00_path_args() -> None:
 
     # test multiple path-args (each loop pops the arg of the highest precedence)
     args = [  # list in decreasing order of precedence
-        ("directory", directory, {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"}),
+        ("directory", "/path/to/dir/", {"$regex": r"^/path/to/dir((/)|(/.*/)).*$"}),
         # not testing "filename" b/c that is equal to "directory" in precedence
-        ("logical_name", logical_name, logical_name),
-        ("path", path, path),
-        ("path-regex", path_regex, {"$regex": path_regex}),
+        ("logical_name", "LOGICAL_NAME", "LOGICAL_NAME"),
+        ("path", "PATH", "PATH"),
+        ("path-regex", r"this.*is?a.path", {"$regex": r"this.*is?a.path"}),
     ]
     while args:
         kwargs = {k: v for (k, v, _) in args}

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,3 +1,8 @@
+"""Test /api/collections."""
+
+# fmt:off
+# pylint: skip-file
+
 from __future__ import absolute_import, division, print_function
 
 import os
@@ -5,8 +10,9 @@ import unittest
 
 from rest_tools.client import RestClient
 
-from .test_server import TestServerAPI
 from .test_files import hex
+from .test_server import TestServerAPI
+
 
 class TestCollectionsAPI(TestServerAPI):
     def test_10_collections(self):
@@ -183,7 +189,7 @@ class TestCollectionsAPI(TestServerAPI):
         self.assertIn('file', data)
         url = data['file']
         file_uid = url.split('/')[-1]
-        
+
         # old snapshot stays empty
         data = r.request_seq('GET', '/api/snapshots/{}/files'.format(snap_uid))
         self.assertEqual(data['files'], [])
@@ -201,7 +207,7 @@ class TestCollectionsAPI(TestServerAPI):
         self.assertEqual(len(data['files']), 1)
         self.assertEqual(data['files'][0]['uuid'], file_uid)
         self.assertEqual(data['files'][0]['checksum'], metadata['checksum'])
-        
+
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestStringMethods)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,4 +1,7 @@
+"""Test /api/files."""
+
 # fmt:off
+# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 
@@ -6,10 +9,8 @@ import hashlib
 import os
 import unittest
 
-from tornado.escape import json_decode, json_encode
-
-# local imports
 from rest_tools.client import RestClient
+from tornado.escape import json_decode, json_encode
 
 from .test_server import TestServerAPI
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,22 +1,27 @@
+"""Test REST Server."""
+
+# fmt:off
+# pylint: skip-file
+
 from __future__ import absolute_import, division, print_function
 
+import hashlib
 import os
-import time
-import tempfile
-import shutil
 import random
+import shutil
 import subprocess
+import tempfile
+import time
+import unittest
 from functools import partial
 from threading import Thread
-import unittest
-import hashlib
 
-from tornado.escape import json_encode,json_decode
-from tornado.ioloop import IOLoop
 import requests
-from pymongo import MongoClient
-
 from file_catalog.urlargparse import encode as jquery_encode
+from pymongo import MongoClient
+from tornado.escape import json_decode, json_encode
+from tornado.ioloop import IOLoop
+
 
 class TestServerAPI(unittest.TestCase):
     def setUp(self):
@@ -35,7 +40,7 @@ class TestServerAPI(unittest.TestCase):
                                   '--logpath', dblog])
             self.addCleanup(partial(time.sleep, 0.3))
             self.addCleanup(m.terminate)
-        
+
     def clean_db(self, host, port):
         db = MongoClient(host=host, port=port).file_catalog
         colls = db.list_collection_names()


### PR DESCRIPTION
Introduces support for shortcut/base request arguments:
- `"directory"` and/or `"filename"`
     - query by directory path and/or the filename
     - Ex: `{"directory": "/foo/bar"}` -> `["/foo/bar/ham.i3", "/foo/bar/green.i3", "/foo/bar/eggs/ham.i3"]`
     - Ex: `{"directory": "/foo/bar", "filename": "ham.i3"}` -> `["/foo/bar/ham.i3", "/foo/bar/eggs/ham.i3"]`
     - Ex: `{"filename": "ham.i3"}` -> `["/foo/bar/ham.i3", "/foo/bar/eggs/ham.i3", "/beef/pork/ham.i3"]`
- `"path"` 
     - query by filepath (currently just a pseudonym for `"logical_name"`)
- `"path-regex"` 
     - query by regex

#### NOTE: With the exception of `"directory"` & `"filename"`, these arguments are mutually exclusive
#### Order of precedence (decreasing): 
1.  `"directory"` & `"filename"`
1.  `"logical_name"` 
2. `"path"`
5. `"path-regex"` 
6. `"logical_name"` sub-field within the `"query"` dict

closes https://github.com/WIPACrepo/file_catalog/issues/77