### PR TITLE
Script to Restore From Backup

### DIFF
--- a/resources/cleanup_scripts/deduplicate.py
+++ b/resources/cleanup_scripts/deduplicate.py
@@ -7,7 +7,6 @@ where the duplicate is indexed under /mnt/lfs*/.
 import argparse
 import json
 import logging
-import os
 from itertools import count
 from typing import Any, Dict, Generator, List, Set, cast
 

--- a/resources/cleanup_scripts/deduplicate.py
+++ b/resources/cleanup_scripts/deduplicate.py
@@ -129,15 +129,6 @@ def _resolve_wipac_location_filepath(fc_meta: FCMetadata) -> FCMetadata:
     return fc_meta
 
 
-def _resolve_season_value(fc_meta: FCMetadata) -> FCMetadata:
-    """Cast `"season"` value to an `int` if it's not `None`."""
-    if "offline_processing_metadata" in fc_meta:
-        season = fc_meta["offline_processing_metadata"]["season"]
-        if fc_meta["offline_processing_metadata"]["season"] is not None:
-            fc_meta["offline_processing_metadata"]["season"] = int(season)
-    return fc_meta
-
-
 def has_good_twin(rc: RestClient, evil_twin: FCMetadata) -> bool:
     """Return whether the `evil_twin` has a good twin.
 
@@ -166,9 +157,6 @@ def has_good_twin(rc: RestClient, evil_twin: FCMetadata) -> bool:
     evil_twin = _resolve_deprecated_fields(evil_twin)
     evil_twin = _resolve_gcd_filepath(evil_twin)
     evil_twin = _resolve_wipac_location_filepath(evil_twin)
-    #
-    evil_twin = _resolve_season_value(evil_twin)
-    good_twin = _resolve_season_value(good_twin)
 
     # compare metadata
     try:

--- a/resources/cleanup_scripts/deduplicate.py
+++ b/resources/cleanup_scripts/deduplicate.py
@@ -129,16 +129,11 @@ def _resolve_wipac_location_filepath(fc_meta: FCMetadata) -> FCMetadata:
     return fc_meta
 
 
-def has_good_twin(rc: RestClient, evil_twin: FCMetadata) -> bool:
-    """Return whether the `evil_twin` has a good twin.
+def are_compatible_twins(evil_twin: FCMetadata, good_twin: FCMetadata) -> bool:
+    """Compare twins.
 
     If the two sets of metadata are not compatible, raise an Exception.
     """
-    try:
-        good_twin = _find_fc_metadata(rc, _get_good_path(evil_twin["logical_name"]))
-    except FileNotFoundError:
-        return False
-
     # compare `create_date` fields
     if "create_date" not in good_twin:
         raise Exception(
@@ -194,6 +189,16 @@ def has_good_twin(rc: RestClient, evil_twin: FCMetadata) -> bool:
         raise
 
     return True
+
+
+def has_good_twin(rc: RestClient, evil_twin: FCMetadata) -> bool:
+    """Return whether the `evil_twin` has a good twin."""
+    try:
+        good_twin = _find_fc_metadata(rc, _get_good_path(evil_twin["logical_name"]))
+    except FileNotFoundError:
+        return False
+
+    return are_compatible_twins(evil_twin, good_twin)
 
 
 def bad_fc_metadata(rc: RestClient) -> Generator[FCMetadata, None, None]:

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -34,7 +34,8 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
 
     PUT if FC entry already exists. Otherwise, POST with uuid.
     """
-    for fcm in fc_entries:
+    for i, fcm in enumerate(fc_entries):
+        print(f"{i}/{len(fc_entries)}")
         logging.debug(fcm)
         if dryrun:
             continue

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -50,7 +50,7 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
                 f"Entry is already in the FC ({fcm['uuid']}); Replacing (PUT)..."
             )
             if dryrun:
-                logging.warning("DEBUG MODE ON: not sending PUT request")
+                logging.warning("DRYRUN MODE ON: not sending PUT request")
             else:
                 await rc.request("PUT", f'/api/files/{fcm["uuid"]}', fcm)
         else:
@@ -58,7 +58,7 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
                 f"Entry is not already in the FC ({fcm['uuid']}); Posting (POST)..."
             )
             if dryrun:
-                logging.warning("DEBUG MODE ON: not sending POST request")
+                logging.warning("DRYRUN MODE ON: not sending POST request")
             else:
                 await rc.request("POST", "/api/files", fcm)
 

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -27,6 +27,7 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
         if dryrun:
             continue
         try:
+            logging.debug(fcm)
             logging.info(
                 f"Assuming entry is already in the FC ({fcm['uuid']}); Replacing (PUT)..."
             )

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -1,0 +1,90 @@
+"""Restore FC entries via their JSON backups."""
+
+
+import argparse
+import asyncio
+import json
+import logging
+from typing import Any, Dict, List, cast
+
+import coloredlogs  # type: ignore[import]
+import requests
+from rest_tools.client import RestClient  # type: ignore[import]
+
+FCMetadata = Dict[str, Any]
+
+
+POP_KEYS = ["meta_modify_date", "_id"]
+
+
+async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) -> None:
+    """Send the fc_entries one-by-one to the FC.
+
+    First try to PUT with existing uuid. If that fails, then POST with
+    uuid.
+    """
+    for fcm in fc_entries:
+        if dryrun:
+            continue
+        try:
+            logging.info("Assuming entry is already in the FC; Replacing (PUT)...")
+            await rc.request("PUT", f'/api/files/{fcm["uuid"]}', fcm)
+        except requests.exceptions.HTTPError as e:
+            logging.debug(e)
+            if e.response.status_code == 400:  # time to POST
+                logging.info("Entry is not already in the FC; Retrying (POST)...")
+                await rc.request("POST", "/api/files", fcm)
+            else:
+                logging.warning(e)
+
+
+def get_fc_entries(file: str) -> List[FCMetadata]:
+    """Parse out the FC metadata/entries from the JSON file."""
+
+    def parse(line: str) -> FCMetadata:
+        fc_meta = cast(FCMetadata, json.loads(line.strip()))
+        for key in POP_KEYS:
+            fc_meta.pop(key)
+        if "uuid" not in fc_meta:
+            raise Exception(f"FC entry is missing a `uuid` field: {fc_meta}")
+        return fc_meta
+
+    fc_entries = [parse(ln) for ln in open(file)]
+    logging.info(f"Parsed {len(fc_entries)} FC entries from {file}")
+    return fc_entries
+
+
+def main() -> None:
+    """Do Main."""
+    # Args
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=f"Restores FC entries from a JSON file (new-line delimited). "
+        f"The contents of each entry is not altered. "
+        f"However, these keys are removed prior to sending to the File Catalog: {POP_KEYS}. "
+        f"Each entry must include a `uuid` field.",
+    )
+    parser.add_argument(
+        "--json", required=True, help="JSON backup file (new-line delimited)"
+    )
+    parser.add_argument("--token", required=True, help="file catalog token")
+    parser.add_argument("--timeout", type=int, default=3600, help="REST-client timeout")
+    parser.add_argument("--retries", type=int, default=24, help="REST-client retries")
+    parser.add_argument("--dryrun", default=False, action="store_true")
+    parser.add_argument("-l", "--log", default="INFO", help="output logging level")
+    args = parser.parse_args()
+
+    coloredlogs.install(level=args.log)
+    rc = RestClient(
+        "https://file-catalog.icecube.wisc.edu/",
+        token=args.token,
+        timeout=args.timeout,
+        retries=args.retries,
+    )
+
+    fc_entries = get_fc_entries(args.json)
+    asyncio.get_event_loop().run_until_complete(restore(rc, fc_entries, args.dryrun))
+
+
+if __name__ == "__main__":
+    main()

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -45,7 +45,7 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
             await rc.request("PUT", f'/api/files/{fcm["uuid"]}', fcm)
         else:
             logging.info(
-                f"Entry is not already in the FC ({fcm['uuid']}); Retrying (POST)..."
+                f"Entry is not already in the FC ({fcm['uuid']}); Posting (POST)..."
             )
             await rc.request("POST", "/api/files", fcm)
 

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -31,11 +31,12 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
             await rc.request("PUT", f'/api/files/{fcm["uuid"]}', fcm)
         except requests.exceptions.HTTPError as e:
             logging.debug(e)
-            if e.response.status_code == 400:  # time to POST
+            if e.response.status_code == 404:  # file not found
                 logging.info("Entry is not already in the FC; Retrying (POST)...")
                 await rc.request("POST", "/api/files", fcm)
             else:
                 logging.warning(e)
+                raise
 
 
 def get_fc_entries(file: str) -> List[FCMetadata]:

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -85,6 +85,8 @@ def main() -> None:
     fc_entries = get_fc_entries(args.json)
     asyncio.get_event_loop().run_until_complete(restore(rc, fc_entries, args.dryrun))
 
+    logging.info("Done.")
+
 
 if __name__ == "__main__":
     main()

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -49,18 +49,20 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
             logging.info(
                 f"Entry is already in the FC ({fcm['uuid']}); Replacing (PUT)..."
             )
-            if dryrun:
+            if dryrun:  # pylint: disable=no-else-continue
                 logging.warning("DEBUG MODE ON: not sending PUT request")
                 continue
-            await rc.request("PUT", f'/api/files/{fcm["uuid"]}', fcm)
+            else:
+                await rc.request("PUT", f'/api/files/{fcm["uuid"]}', fcm)
         else:
             logging.info(
                 f"Entry is not already in the FC ({fcm['uuid']}); Posting (POST)..."
             )
-            if dryrun:
+            if dryrun:  # pylint: disable=no-else-continue
                 logging.warning("DEBUG MODE ON: not sending POST request")
                 continue
-            await rc.request("POST", "/api/files", fcm)
+            else:
+                await rc.request("POST", "/api/files", fcm)
 
 
 def get_fc_entries(file: str) -> List[FCMetadata]:

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -44,9 +44,10 @@ def get_fc_entries(file: str) -> List[FCMetadata]:
     def parse(line: str) -> FCMetadata:
         fc_meta = cast(FCMetadata, json.loads(line.strip()))
         for key in POP_KEYS:
-            fc_meta.pop(key)
+            fc_meta.pop(key, None)
         if "uuid" not in fc_meta:
             raise Exception(f"FC entry is missing a `uuid` field: {fc_meta}")
+        logging.debug(fc_meta)
         return fc_meta
 
     fc_entries = [parse(ln) for ln in open(file)]
@@ -75,6 +76,9 @@ def main() -> None:
     args = parser.parse_args()
 
     coloredlogs.install(level=args.log)
+    for arg, val in vars(args).items():
+        logging.warning(f"{arg}: {val}")
+
     rc = RestClient(
         "https://file-catalog.icecube.wisc.edu/",
         token=args.token,

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -44,17 +44,22 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
     for i, fcm in enumerate(fc_entries):
         print(f"{i}/{len(fc_entries)}")
         logging.debug(fcm)
-        if dryrun:
-            continue
+
         if await already_in_fc(rc, fcm["uuid"], fcm["logical_name"]):
             logging.info(
                 f"Entry is already in the FC ({fcm['uuid']}); Replacing (PUT)..."
             )
+            if dryrun:
+                logging.warning("DEBUG MODE ON: not sending PUT request")
+                continue
             await rc.request("PUT", f'/api/files/{fcm["uuid"]}', fcm)
         else:
             logging.info(
                 f"Entry is not already in the FC ({fcm['uuid']}); Posting (POST)..."
             )
+            if dryrun:
+                logging.warning("DEBUG MODE ON: not sending POST request")
+                continue
             await rc.request("POST", "/api/files", fcm)
 
 

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -27,12 +27,16 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
         if dryrun:
             continue
         try:
-            logging.info("Assuming entry is already in the FC; Replacing (PUT)...")
+            logging.info(
+                f"Assuming entry is already in the FC ({fcm['uuid']}); Replacing (PUT)..."
+            )
             await rc.request("PUT", f'/api/files/{fcm["uuid"]}', fcm)
         except requests.exceptions.HTTPError as e:
             logging.debug(e)
             if e.response.status_code == 404:  # file not found
-                logging.info("Entry is not already in the FC; Retrying (POST)...")
+                logging.info(
+                    f"Entry is not already in the FC ({fcm['uuid']}); Retrying (POST)..."
+                )
                 await rc.request("POST", "/api/files", fcm)
             else:
                 logging.warning(e)

--- a/resources/cleanup_scripts/restore_from_backup.py
+++ b/resources/cleanup_scripts/restore_from_backup.py
@@ -49,18 +49,16 @@ async def restore(rc: RestClient, fc_entries: List[FCMetadata], dryrun: bool) ->
             logging.info(
                 f"Entry is already in the FC ({fcm['uuid']}); Replacing (PUT)..."
             )
-            if dryrun:  # pylint: disable=no-else-continue
+            if dryrun:
                 logging.warning("DEBUG MODE ON: not sending PUT request")
-                continue
             else:
                 await rc.request("PUT", f'/api/files/{fcm["uuid"]}', fcm)
         else:
             logging.info(
                 f"Entry is not already in the FC ({fcm['uuid']}); Posting (POST)..."
             )
-            if dryrun:  # pylint: disable=no-else-continue
+            if dryrun:
                 logging.warning("DEBUG MODE ON: not sending POST request")
-                continue
             else:
                 await rc.request("POST", "/api/files", fcm)
 


### PR DESCRIPTION
Added a script to restore FC entries via their JSON backups.

> Restores FC entries from a JSON file (new-line delimited). The contents of each entry is not altered. However, these keys are removed prior to sending to the File Catalog: ["meta_modify_date", "_id"]. Each entry must include a `uuid` field.

First try to PUT with existing uuid. If that fails (404), then POST with uuid.

You're on your own for any field alterations.