### PR TITLE
Allow Non-Unique `logical_name`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Obtain list of files
 ##### REST-Query Parameters
   * [`limit`](#limit)
   * [`start`](#start)
-  * [`path` *or* `logical_name`](#shortcut-parameters-path-regex-path-logical_name-directory-filename) *(shortcut parameter)*
-  * [`directory`](#shortcut-parameters-path-regex-path-logical_name-directory-filename) *(shortcut parameter)*
-  * [`filename`](#shortcut-parameters-path-regex-path-logical_name-directory-filename) *(shortcut parameter)*
-  * [`path-regex`](#shortcut-parameters-path-regex-path-logical_name-directory-filename) *(shortcut parameter)*
+  * [`logical_name`](#shortcut-parameters-logical-name-regex-logical_name-directory-filename) *(shortcut parameter)*
+  * [`directory`](#shortcut-parameters-logical-name-regex-logical_name-directory-filename) *(shortcut parameter)*
+  * [`filename`](#shortcut-parameters-logical-name-regex-logical_name-directory-filename) *(shortcut parameter)*
+  * [`logical-name-regex`](#shortcut-parameters-logical-name-regex-logical_name-directory-filename) *(shortcut parameter)*
   * [`run_number`](#shortcut-parameter-run_number) *(shortcut parameter)*
   * [`dataset`](#shortcut-parameter-dataset) *(shortcut parameter)*
   * [`event_id`](#shortcut-parameter-event_id) *(shortcut parameter)*
@@ -208,13 +208,13 @@ Partially update/replace file metadata information
 - **NOTE:** there is no performance hit for including more fields
 - *see [`all-keys`](#shortcut-parameter-all-keys)*
 
-##### Shortcut Parameters: `path-regex`, `path`, `logical_name`, `directory`, `filename`
+##### Shortcut Parameters: `logical-name-regex`, `logical_name`, `directory`, `filename`
 *In decreasing order of precedence...*
-- `path-regex`
+- `logical-name-regex`
   - query by regex pattern (at your own risk... performance-wise)
   - equivalent to: `query: {"logical_name": {"$regex": p}}`
 
-- `path` *or* `logical_name`
+- `logical_name`
   - equivalent to: `query["logical_name"]`
 
 - `directory`

--- a/file_catalog/argbuilder.py
+++ b/file_catalog/argbuilder.py
@@ -3,8 +3,9 @@
 
 from typing import Any, Dict, Optional, Union
 
-from file_catalog.mongo import AllKeys
 from tornado.escape import json_decode
+
+from file_catalog.mongo import AllKeys
 
 
 def build_limit(kwargs: Dict[str, Any], config: Dict[str, Any]) -> None:
@@ -30,30 +31,28 @@ def build_start(kwargs: Dict[str, Any]) -> None:
             raise Exception("start is negative")
 
 
-def _resolve_path_args(kwargs: Dict[str, Any]) -> Optional[Union[Dict[str, Any], str]]:
-    """Resolve the path-type shortcut arguments by precedence.
+def _resolve_name_args(kwargs: Dict[str, Any]) -> Optional[Union[Dict[str, Any], str]]:
+    """Resolve the name-type shortcut arguments by precedence.
 
     Pop each key from `kwargs`, even if it's not used.
     """
     arg: Optional[Union[Dict[str, Any], str]] = None
 
     # regex
-    if "path-regex" in kwargs:
-        arg = {"$regex": kwargs.pop("path-regex")}
+    if "logical-name-regex" in kwargs:
+        arg = {"$regex": kwargs.pop("logical-name-regex")}
 
     # normal path
-    if "path" in kwargs:
-        arg = kwargs.pop("path")
     if "logical_name" in kwargs:
         arg = kwargs.pop("logical_name")
 
     # directory & filename
     if "directory" in kwargs or "filename" in kwargs:
-        if not (dpath := kwargs.pop("directory", "").rstrip("/")):
-            dpath = r".*"
+        if not (directory := kwargs.pop("directory", "").rstrip("/")):
+            directory = r".*"
         if not (fname := kwargs.pop("filename", "").lstrip("/")):
             fname = r".*"
-        arg = {"$regex": rf"^{dpath}/(.*/)?{fname}$"}
+        arg = {"$regex": rf"^{directory}/(.*/)?{fname}$"}
 
     return arg
 
@@ -76,7 +75,7 @@ def build_files_query(kwargs: Dict[str, Any]) -> None:
         query["locations.archive"] = None
 
     # shortcut query params
-    if path := _resolve_path_args(kwargs):
+    if path := _resolve_name_args(kwargs):
         query["logical_name"] = path
     if "run_number" in kwargs:
         query["run.run_number"] = kwargs.pop("run_number")

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -348,6 +348,8 @@ class APIHandler(tornado.web.RequestHandler):
         self.base_url = base_url
         self.debug = debug
         self.config = config
+        self.validation = Validation(self.config)
+
         if 'TOKEN_KEY' in self.config:
             self.auth = Auth(algorithm=self.config['TOKEN_ALGORITHM'],
                              secret=self.config['TOKEN_KEY'],
@@ -437,7 +439,6 @@ class FilesHandler(APIHandler):
         super().initialize(**kwargs)
         # pylint: disable=W0201
         self.files_url = os.path.join(self.base_url, 'files')
-        self.validation = Validation(self.config)  # pylint: disable=W0201
 
     @validate_auth
     @catch_error
@@ -525,7 +526,6 @@ class FilesCountHandler(APIHandler):
         super().initialize(**kwargs)
         # pylint: disable=W0201
         self.files_url = os.path.join(self.base_url, 'files')
-        self.validation = Validation(self.config)
 
     @validate_auth
     @catch_error
@@ -561,7 +561,6 @@ class SingleFileHandler(APIHandler):
         super().initialize(**kwargs)
         # pylint: disable=W0201
         self.files_url = os.path.join(self.base_url, 'files')
-        self.validation = Validation(self.config)
 
     @validate_auth
     @catch_error
@@ -709,9 +708,9 @@ class SingleFileLocationsHandler(APIHandler):
             self.send_error(400, reason="POST body requires 'locations' field")
             return
 
-        # if locations isn't a list
-        if not isinstance(locations, list):
-            self.send_error(400, reason=f"Field 'locations' must be a list (not `{type(locations)}`)")
+        # validate `locations`
+        if not self.validation.is_valid_location_list(locations):
+            self.send_error(400, reason=self.validation.INVALID_LOCATIONS_LIST_MESSAGE)
             return
 
         # for each location provided

--- a/tests/test_argbuilder.py
+++ b/tests/test_argbuilder.py
@@ -25,17 +25,11 @@ def test_00_path_args() -> None:
             "kwargs_after": {"an-extra-argument": [12, 34, 56]},
             "ret": None,
         },
-        # only "path-regex"
+        # only "logical-name-regex"
         {
-            "kwargs_in": {"path-regex": r"/reg-ex/this.*/(file/)?path"},
+            "kwargs_in": {"logical-name-regex": r"/reg-ex/this.*/(file/)?path"},
             "kwargs_after": {},
             "ret": {"$regex": r"/reg-ex/this.*/(file/)?path"},
-        },
-        # only "path"
-        {
-            "kwargs_in": {"an-extra-argument": [12, 34, 56], "path": "PATH"},
-            "kwargs_after": {"an-extra-argument": [12, 34, 56]},
-            "ret": "PATH",
         },
         # only "logical_name"
         {
@@ -78,7 +72,7 @@ def test_00_path_args() -> None:
     for ktd in kwargs_test_dicts:
         pprint.pprint(ktd)
         print()
-        assert argbuilder._resolve_path_args(ktd["kwargs_in"]) == ktd["ret"]
+        assert argbuilder._resolve_name_args(ktd["kwargs_in"]) == ktd["ret"]
         assert ktd["kwargs_in"] == ktd["kwargs_after"]
 
     # test multiple path-args (each loop pops the arg of the highest precedence)
@@ -86,12 +80,11 @@ def test_00_path_args() -> None:
         ("directory", "/path/to/dir/", {"$regex": r"^/path/to/dir/(.*/)?.*$"}),
         # not testing "filename" b/c that is equal to "directory" in precedence
         ("logical_name", "LOGICAL_NAME", "LOGICAL_NAME"),
-        ("path", "PATH", "PATH"),
-        ("path-regex", r"this.*is?a.path", {"$regex": r"this.*is?a.path"}),
+        ("logical-name-regex", r"this.*is?a.path", {"$regex": r"this.*is?a.path"}),
     ]
     while args:
         kwargs = {k: v for (k, v, _) in args}
         pprint.pprint(kwargs)
-        assert argbuilder._resolve_path_args(kwargs) == args[0][2]
+        assert argbuilder._resolve_name_args(kwargs) == args[0][2]
         assert not kwargs  # everything was popped
         args.pop(0)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -167,7 +167,7 @@ class TestFilesAPI(TestServerAPI):
     def test_13_files_path_like_args(self) -> None:
         """Test the path-like base/shortcut arguments.
 
-        "logical_name", "directory", "filename", "path", & "path-regex".
+        "logical_name", "directory", "filename", "path", & "logical-name-regex".
         """
         self.start_server()
         token = self.get_token()
@@ -231,10 +231,10 @@ class TestFilesAPI(TestServerAPI):
         # directory & filename
         paths = get_paths({"directory": "/foo", "filename": "ham.txt"})
         assert paths == ["/foo/bar/ham.txt"]
-        # path-regex
-        paths = get_paths({"path-regex": r".*george/ringo.*"})
+        # logical-name-regex
+        paths = get_paths({"logical-name-regex": r".*george/ringo.*"})
         assert paths == ["/john/paul/george/ringo/ham.txt"]
-        assert len(get_paths({"path-regex": r".*"})) == 4
+        assert len(get_paths({"logical-name-regex": r".*"})) == 4
 
     def test_15_files_auth(self) -> None:
         """Test auth/token; good and bad (403) cases.


### PR DESCRIPTION
- Allows the use of non-unique logical names
	+ This allows the versioning of files. For example, version 0 is at NERSC and version 1 is at WIPAC.
	+ `checksum`+`logical_name` is unique. This represents a file version. The `create_date` identifies the age of the file version.
- Validates incoming location-type entries

from https://github.com/WIPACrepo/file_catalog/issues/109