### PR TITLE
Add Timeout to Mongo Queries 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Obtain list of files
   * [`query`](#query)
   * [`keys`](#keys)
   * [`all-keys`](#shortcut-parameter-all-keys) *(shortcut parameter)*
+  * [`max_time_ms`](#max_time_ms)
 
 ##### HTTP Response Status Codes
   * `200`: Response contains collection of file resources
@@ -207,6 +208,11 @@ Partially update/replace file metadata information
 - different routes/methods define differing defaults
 - **NOTE:** there is no performance hit for including more fields
 - *see [`all-keys`](#shortcut-parameter-all-keys)*
+
+##### `max_time_ms`
+- *non-negative integer OR `None`;* timeout to kill long queries in MILLISECONDS
+- overrides the default timeout of 600000 ms (10 minutes)
+- `None` indicates no timeout (this can hang the server -- you have been warned)
 
 ##### Shortcut Parameters: `path-regex`, `path`, `logical_name`, `directory`, `filename`
 *In decreasing order of precedence...*

--- a/file_catalog/mongo.py
+++ b/file_catalog/mongo.py
@@ -18,6 +18,9 @@ from .schema import types
 logger = logging.getLogger("mongo")
 
 
+DEFAULT_MAX_TIME_MS = 10 * 60 * 1000  # 10 minutes
+
+
 class AllKeys:  # pylint: disable=R0903
     """Include all keys in MongoDB find*() methods."""
 
@@ -115,7 +118,9 @@ class Mongo:
 
     @staticmethod
     async def _limit_result_list(
-        cursor: MotorCursor, limit: Optional[int] = None, start: int = 0,
+        cursor: MotorCursor,
+        limit: Optional[int] = None,
+        start: int = 0,
     ) -> List[Dict[str, Any]]:
         """Get sublist of results from `cursor` using `limit` and `start`."""
         if limit:
@@ -130,6 +135,7 @@ class Mongo:
         keys: Optional[Union[List[str], AllKeys]] = None,
         limit: Optional[int] = None,
         start: int = 0,
+        max_time_ms: Optional[int] = DEFAULT_MAX_TIME_MS,
     ) -> List[Dict[str, Any]]:
         """Find files.
 
@@ -143,6 +149,7 @@ class Mongo:
             keys -- fields to include in MongoDB projection
             limit -- max count of files returned
             start -- starting index
+            max_time_ms -- the query timeout in milliseconds
 
         Returns:
             List of MongoDB files
@@ -150,13 +157,15 @@ class Mongo:
         projection = Mongo._get_projection(
             keys, default={"uuid": True, "logical_name": True}
         )
-        cursor = self.client.files.find(query, projection)
+        cursor = self.client.files.find(query, projection, max_time_ms=max_time_ms)
         results = await Mongo._limit_result_list(cursor, limit, start)
 
         return results
 
     async def count_files(  # pylint: disable=W0613
-        self, query: Optional[Dict[str, Any]] = None, **kwargs: Any,
+        self,
+        query: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> int:
         """Get count of files matching query."""
         if not query:
@@ -180,9 +189,13 @@ class Mongo:
 
         return metadata["uuid"]
 
-    async def get_file(self, filters: Dict[str, Any]) -> types.Metadata:
+    async def get_file(
+        self, filters: Dict[str, Any], max_time_ms: Optional[int] = DEFAULT_MAX_TIME_MS
+    ) -> types.Metadata:
         """Get file matching filters."""
-        file = await self.client.files.find_one(filters, {"_id": False})
+        file = await self.client.files.find_one(
+            filters, {"_id": False}, max_time_ms=max_time_ms
+        )
         return cast(types.Metadata, file)
 
     async def update_file(self, uuid: str, metadata: types.Metadata) -> None:


### PR DESCRIPTION
This will solve the problem of bad queries hanging the server.

Add a 10-minute default timeout to all Mongo queries
Add an argument to `/api/files`:`GET` called `max_time_ms` to configure this timeout