### PR TITLE
Allow configuration of service address

### DIFF
--- a/file_catalog/config.py
+++ b/file_catalog/config.py
@@ -28,6 +28,9 @@ class Config(Dict[str, Optional[Union[bool, int, str]]]):
         'FC_COOKIE_SECRET': ConfigParamSpec(
             None, str, 'Value of cookie_secret argument for tornado.web.Application'
         ),
+        'FC_HOST': ConfigParamSpec(
+            'localhost', str, 'Address for File Catalog server to bind for listening (default: localhost)'
+        ),
         'FC_PORT': ConfigParamSpec(
             8888, int, 'Port for File Catalog server to listen on'
         ),

--- a/file_catalog/server.py
+++ b/file_catalog/server.py
@@ -163,8 +163,9 @@ def create(config: Dict[str, Any],
     server.add_route(r"/api/snapshots/([^\/]+)",                     SingleSnapshotHandler,                  args)  # type: ignore[no-untyped-call]  # noqa: E221, E241, E251
     server.add_route(r"/api/snapshots/([^\/]+)/files",               SingleSnapshotFilesHandler,             args)  # type: ignore[no-untyped-call]  # noqa: E221, E241, E251
 
+    address = config["FC_HOST"]
     port = config["FC_PORT"]
-    server.startup(port=port)  # type: ignore[no-untyped-call]
+    server.startup(address=address, port=port)  # type: ignore[no-untyped-call]
 
     return server
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,7 +34,7 @@ coverage[toml]==7.2.2
     # via pytest-cov
 crawler==0.0.2
     # via wipac-file-catalog (setup.py)
-cryptography==40.0.0
+cryptography==40.0.1
     # via pyjwt
 deprecated==1.2.13
     # via opentelemetry-api
@@ -50,7 +50,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.51.3
+grpcio==1.53.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -170,13 +170,13 @@ tornado==6.2
     #   wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt
-types-pymysql==1.0.19.5
+types-pymysql==1.0.19.6
     # via wipac-file-catalog (setup.py)
-types-python-dateutil==2.8.19.10
+types-python-dateutil==2.8.19.11
     # via wipac-file-catalog (setup.py)
-types-requests==2.28.11.16
+types-requests==2.28.11.17
     # via wipac-file-catalog (setup.py)
-types-urllib3==1.26.25.8
+types-urllib3==1.26.25.10
     # via types-requests
 typing-extensions==4.5.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ coloredlogs==15.0.1
     # via
     #   wipac-file-catalog (setup.py)
     #   wipac-telemetry
-cryptography==40.0.0
+cryptography==40.0.1
     # via pyjwt
 deprecated==1.2.13
     # via opentelemetry-api
@@ -26,7 +26,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.51.3
+grpcio==1.53.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,7 @@ async def rest(monkeypatch: MonkeyPatch, mongo: Mongo, port: int) -> AsyncGenera
     config: Dict[str, Any] = {
         "AUTH_AUDIENCE": "file-catalog-testing",
         "AUTH_OPENID_URL": "https://keycloak.icecube.wisc.edu/auth/realms/IceCube",
+        "FC_HOST": "localhost",
         "FC_PORT": port,
         "FC_PUBLIC_URL": f"http://localhost:{port}",
         "FC_QUERY_FILE_LIST_LIMIT": 10000,


### PR DESCRIPTION
Add `FC_HOST` as a configuration parameter that allows the service address to be specified.
Defaults to `localhost` (like the underlying rest_tools library)

Use `FC_HOST=""` to listen on any address

Source: https://icecube-spno.slack.com/archives/CAH0NDF8B/p1680027845897069
